### PR TITLE
Make state endpoint request helpers private to remote module

### DIFF
--- a/src/fallback.rs
+++ b/src/fallback.rs
@@ -11,7 +11,7 @@ use thiserror::Error;
 use tokio::sync::RwLock;
 use tracing::{debug, field, instrument, trace, warn};
 
-use crate::request::{make_uri, UriError};
+use crate::util::uri::{make_uri, UriError};
 
 #[derive(Debug, Deserialize)]
 struct StateStatusResponse {

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,8 +17,8 @@ mod config;
 mod fallback;
 mod register;
 mod remote;
-mod request;
 mod target;
+mod util;
 
 use crate::cli::Command;
 use crate::config::Config;

--- a/src/remote/mod.rs
+++ b/src/remote/mod.rs
@@ -5,8 +5,11 @@ use std::time::Duration;
 use tokio::time::Instant;
 use tracing::{field, info_span, instrument, warn, Span};
 
+mod request;
+
 use crate::config::Config;
-use crate::request::{make_uri, Get, Patch, RequestConfig};
+use crate::util::uri::make_uri;
+use request::{Get, Patch, RequestConfig};
 
 pub fn get_poll_client(config: &Config) -> Option<Get> {
     if let Some(uri) = config.remote.api_endpoint.clone() {

--- a/src/remote/request.rs
+++ b/src/remote/request.rs
@@ -1,31 +1,7 @@
-use axum::http::uri::PathAndQuery;
-use axum::http::{StatusCode, Uri};
-use std::{
-    str::FromStr,
-    time::{Duration, Instant},
-};
+use axum::http::StatusCode;
+use std::time::{Duration, Instant};
 use thiserror::Error;
 use tracing::{field, instrument, Span};
-
-#[derive(Debug, Error)]
-pub enum UriError {
-    #[error(transparent)]
-    InvalidUri(#[from] axum::http::uri::InvalidUri),
-
-    #[error(transparent)]
-    InvalidUriParts(#[from] axum::http::uri::InvalidUriParts),
-}
-
-pub fn make_uri(base_uri: Uri, path: &str, query: Option<&str>) -> Result<Uri, UriError> {
-    // Build the URI from the address parts
-    let mut parts = base_uri.into_parts();
-    parts.path_and_query = if let Some(qs) = query {
-        Some(PathAndQuery::from_maybe_shared(format!("{path}?{qs}",))?)
-    } else {
-        Some(PathAndQuery::from_str(path)?)
-    };
-    Uri::from_parts(parts).map_err(|err| err.into())
-}
 
 /// Internal errors that can occur during HTTP GET requests (including retry logic).
 #[derive(Debug, Error)]

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -1,0 +1,1 @@
+pub mod uri;

--- a/src/util/uri.rs
+++ b/src/util/uri.rs
@@ -1,0 +1,24 @@
+use axum::http::uri::PathAndQuery;
+use axum::http::Uri;
+use std::str::FromStr;
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum UriError {
+    #[error(transparent)]
+    InvalidUri(#[from] axum::http::uri::InvalidUri),
+
+    #[error(transparent)]
+    InvalidUriParts(#[from] axum::http::uri::InvalidUriParts),
+}
+
+pub fn make_uri(base_uri: Uri, path: &str, query: Option<&str>) -> Result<Uri, UriError> {
+    // Build the URI from the address parts
+    let mut parts = base_uri.into_parts();
+    parts.path_and_query = if let Some(qs) = query {
+        Some(PathAndQuery::from_maybe_shared(format!("{path}?{qs}",))?)
+    } else {
+        Some(PathAndQuery::from_str(path)?)
+    };
+    Uri::from_parts(parts).map_err(|err| err.into())
+}


### PR DESCRIPTION
It was previously tempting to either try to use Get/Patch directly as general request helpers, or add unrelated functionality (like we did by adding `make_uri` et al) to the request module.

This moves request as a private submodule of remote, being its sole client/user.

Change-type: patch