### PR TITLE
Add some worker tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -440,6 +440,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "diff"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -698,6 +704,7 @@ dependencies = [
  "futures-lite",
  "mahler",
  "mockito",
+ "pretty_assertions",
  "rand",
  "reqwest",
  "serde",
@@ -1121,9 +1128,9 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "mahler"
-version = "0.17.1"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8f2d654b496d02bdb68f87e06949477a370a9231a2018743bf35bd09053d19e"
+checksum = "6201eb009a9abc98b114fce3c079200a4ecd3b07e673794b3b228215d3196528"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1307,6 +1314,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
+]
+
+[[package]]
+name = "pretty_assertions"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ae130e2f271fbc2ac3a40fb1d07180839cdbbe443c7a27e1e3c13c5cac0116d"
+dependencies = [
+ "diff",
+ "yansi",
 ]
 
 [[package]]
@@ -2561,6 +2578,12 @@ name = "writeable"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea2f10b9bb0928dfb1b42b65e1f9e36f7f54dbdf08457afefb38afcdec4fa2bb"
+
+[[package]]
+name = "yansi"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "yoke"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,13 +45,14 @@ rand = "0.9.2"
 clap = { version = "4.5", features = ["derive", "env"] }
 dirs = "6.0.0"
 uuid = { version = "1.17", features = ["v4"] }
-mahler = { version = "0.17.1" }
+mahler = { version = "0.18.0" }
 bollard = "0.19.1"
 futures-lite = { version = "2.6.0", default-features = false }
 sha2 = { version = "0.10.9", default-features = false }
 
 [dev-dependencies]
 mockito = { version = "1.7", default-features = false }
+pretty_assertions = "1.4.1"
 
 [profile.release]
 opt-level = "z"

--- a/src/state/models.rs
+++ b/src/state/models.rs
@@ -57,12 +57,15 @@ pub struct Device {
     pub uuid: Uuid,
 
     /// List of docker images on the device
+    #[serde(default)]
     pub images: HashMap<String, Image>,
 
     /// Apps on the device
+    #[serde(default)]
     pub apps: HashMap<Uuid, App>,
 
     /// Config vars
+    #[serde(default)]
     pub config: DeviceConfig,
 }
 
@@ -86,7 +89,9 @@ pub type TargetApp = App;
 /// Target state of a device
 #[derive(Serialize, Deserialize, Debug, Default, Clone)]
 pub struct TargetDevice {
+    #[serde(default)]
     pub apps: HashMap<Uuid, TargetApp>,
+    #[serde(default)]
     pub config: DeviceConfig,
 }
 


### PR DESCRIPTION
Adds some basic tests to validate how the worker is calculating the
sequence of operations. This also updates mahler to use the latest
changes in balena-io-modules/mahler-rs#44

These tests allow to trace the planning process using

```
RUST_LOG=trace cargo test worker
```

Change-type: patch