### PR TITLE
Fix registry auth initialization

### DIFF
--- a/helios-remote/src/config.rs
+++ b/helios-remote/src/config.rs
@@ -61,13 +61,13 @@ impl Default for RequestConfig {
     }
 }
 
-impl From<RequestConfig> for request::RequestConfig {
-    fn from(value: RequestConfig) -> Self {
+impl From<RemoteConfig> for request::RequestConfig {
+    fn from(config: RemoteConfig) -> Self {
         Self {
-            timeout: value.timeout,
-            min_interval: value.poll_min_interval,
-            max_backoff: value.poll_interval,
-            auth_token: None,
+            timeout: config.request.timeout,
+            min_interval: config.request.poll_min_interval,
+            max_backoff: config.request.poll_interval,
+            auth_token: Some(config.api_key.into()),
         }
     }
 }

--- a/helios/src/main.rs
+++ b/helios/src/main.rs
@@ -111,7 +111,7 @@ async fn start_supervisor(
 
     let registry_auth = remote_config
         .clone()
-        .map(|c| RegistryAuthClient::new(c.api_endpoint, c.request.into()));
+        .map(|c| RegistryAuthClient::new(c.api_endpoint.clone(), c.into()));
 
     // Set-up channels to trigger state poll, updates and reporting
     let (seek_request_tx, seek_request_rx) = watch::channel(state::SeekRequest::default());


### PR DESCRIPTION
The RegistryAuthClient was using a RequestConfig conversion that used `None` as auth_token, resulting in image pull to fail every time. This modifies the `From` implementation to convert from `RemoteConfig` rather than `RequestConfig`. This also removes the conversion between remote::config::RequestConfig and util::request::RequestConfig that could lead to errors due to the name sharing.

Change-type: patch