### PR TITLE
Add support for Service volumes

### DIFF
--- a/helios-integration-tests/src/api_tests.rs
+++ b/helios-integration-tests/src/api_tests.rs
@@ -146,6 +146,20 @@ async fn assert_network_created(docker: &Docker, oci_name: &str, logical_name: &
     );
 }
 
+/// Locate a mount entry on an inspected container by its `Destination` (target path).
+fn container_mount<'a>(
+    container: &'a bollard::models::ContainerInspectResponse,
+    target: &str,
+) -> &'a bollard::models::MountPoint {
+    container
+        .mounts
+        .as_ref()
+        .expect("container has no mounts")
+        .iter()
+        .find(|m| m.destination.as_deref() == Some(target))
+        .unwrap_or_else(|| panic!("no mount at target '{target}'"))
+}
+
 // --- Teardown ---
 
 async fn delete_app_and_wait(client: &reqwest::Client, app_uuid: &str) {
@@ -244,6 +258,9 @@ async fn test_set_app_target_install_images() {
                             "net-a": { "aliases": ["svc-one-alias"] },
                             "net-b": null,
                         },
+                        "volumes": [
+                            "my-vol:/backup:ro",
+                        ],
                     }
                 }),
             ),
@@ -256,6 +273,24 @@ async fn test_set_app_target_install_images() {
                         "command": ["sleep", "10"],
                         "labels": { "my-label": "true" },
                         "environment": ["MY_KEY=123"],
+                        "volumes": [
+                            {
+                                "type": "volume",
+                                "source": "my-vol",
+                                "target": "/data",
+                                "read_only": true
+                            },
+                            {
+                                "type": "bind",
+                                "source": "/proc",
+                                "target": "/host/proc"
+                            },
+                            {
+                                "type": "tmpfs",
+                                "target": "/run/tmp",
+                                "tmpfs": { "size": 65536, "mode": 448 }
+                            }
+                        ],
                     }
                 }),
             ),
@@ -433,12 +468,52 @@ async fn test_set_app_target_install_images() {
     );
     assert_container_networks(&svc_three_container, &["host"]);
 
-    let my_vol_id = get_resource_oci_name(app, release_uuid, "volumes", "my-vol");
-    let volume = docker.inspect_volume(my_vol_id).await.unwrap();
+    let my_vol_id = get_resource_oci_name(app, release_uuid, "volumes", "my-vol").to_string();
+    let volume = docker.inspect_volume(&my_vol_id).await.unwrap();
     assert_eq!(
         volume.labels.get("io.balena.volume-name").unwrap(),
         "my-vol"
     );
+
+    // service-one received the short-form volume mount `my-vol:/backup:ro`.
+    // Docker reports the mount source as the namespaced volume name.
+    let svc_one_backup = container_mount(&svc_one_container, "/backup");
+    assert_eq!(svc_one_backup.typ.unwrap().as_ref(), "volume");
+    assert_eq!(svc_one_backup.name.as_deref(), Some(my_vol_id.as_str()));
+    assert_eq!(svc_one_backup.rw, Some(false));
+
+    // service-two declares a volume mount, a bind mount, and a tmpfs mount
+    // via the long-form syntax.
+    let svc_two_data = container_mount(&svc_two_container, "/data");
+    assert_eq!(svc_two_data.typ.unwrap().as_ref(), "volume");
+    assert_eq!(svc_two_data.name.as_deref(), Some(my_vol_id.as_str()));
+    assert_eq!(svc_two_data.rw, Some(false));
+
+    let svc_two_machine_id = container_mount(&svc_two_container, "/host/proc");
+    assert_eq!(svc_two_machine_id.typ.unwrap().as_ref(), "bind");
+    assert_eq!(svc_two_machine_id.source.as_deref(), Some("/proc"));
+    assert_eq!(svc_two_machine_id.rw, Some(true));
+
+    let svc_two_tmp = container_mount(&svc_two_container, "/run/tmp");
+    assert_eq!(svc_two_tmp.typ.unwrap().as_ref(), "tmpfs");
+
+    // The host-level tmpfs options that were sent to the engine should round-trip
+    // through the `HostConfig.Mounts` spec.
+    let svc_two_host_mounts = svc_two_container
+        .host_config
+        .as_ref()
+        .and_then(|hc| hc.mounts.as_ref())
+        .expect("host_config.mounts not set");
+    let tmpfs_spec = svc_two_host_mounts
+        .iter()
+        .find(|m| m.target.as_deref() == Some("/run/tmp"))
+        .expect("tmpfs mount not found in host_config.mounts");
+    let tmpfs_opts = tmpfs_spec
+        .tmpfs_options
+        .as_ref()
+        .expect("tmpfs options missing");
+    assert_eq!(tmpfs_opts.size_bytes, Some(65536));
+    assert_eq!(tmpfs_opts.mode, Some(448));
 
     // State report was sent with correct service statuses
     let release_report = wait_for_report(TEST_APP_UUID, release_uuid, "done", 10).await;
@@ -460,4 +535,50 @@ async fn test_set_app_target_install_images() {
     delete_app_and_wait(&client, TEST_APP_UUID).await;
     assert!(docker.inspect_image("ubuntu:latest").await.is_err());
     assert!(docker.inspect_image("alpine:latest").await.is_err());
+}
+
+#[tokio::test]
+async fn test_set_app_target_rejects_bind_mount_not_in_allowlist() {
+    let release_uuid = "reject-release";
+    let release = release_json(
+        &[(
+            "bad-svc",
+            json!({
+                "id": 1,
+                "image": "alpine:latest",
+                "composition": {
+                    "volumes": [
+                        {"type": "bind", "source": "/root", "target": "/root"}
+                    ]
+                }
+            }),
+        )],
+        &[],
+        &[],
+    );
+    let target = app_target_json("reject-app", release_uuid, release);
+
+    let client = reqwest::Client::new();
+    let res = client
+        .post(format!("{HELIOS_URL}/v3/device/apps/{TEST_APP_UUID}"))
+        .json(&target)
+        .send()
+        .await
+        .unwrap();
+
+    // Axum returns a 4xx when the JSON body fails to deserialize; the
+    // remote-model allowlist check fires during deserialization.
+    assert!(
+        res.status().is_client_error(),
+        "expected 4xx, got {}",
+        res.status()
+    );
+
+    // Confirm no app was created.
+    let res = client
+        .get(format!("{HELIOS_URL}/v3/device/apps/{TEST_APP_UUID}"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::NOT_FOUND);
 }

--- a/helios-oci/src/container.rs
+++ b/helios-oci/src/container.rs
@@ -5,7 +5,10 @@ use bollard::{
         ContainerInspectResponse, ContainerStateStatusEnum, EndpointIpamConfig, EndpointSettings,
         HealthStatusEnum, NetworkingConfig, RestartPolicyNameEnum,
     },
-    models::ContainerCreateBody,
+    models::{
+        ContainerCreateBody, MountBindOptions, MountBindOptionsPropagationEnum, MountTmpfsOptions,
+        MountTypeEnum, MountVolumeOptions,
+    },
     query_parameters::{
         CreateContainerOptions, DownloadFromContainerOptions, ListContainersOptions,
         RemoveContainerOptions, RenameContainerOptions,
@@ -256,6 +259,7 @@ impl<N> TryFrom<ContainerInspectResponse> for LocalContainer<N> {
                 "host" => Some(NetworkMode::Host),
                 _ => None,
             });
+
         let restart_policy = host_config
             .as_mut()
             .and_then(|hc| hc.restart_policy.take())
@@ -271,6 +275,19 @@ impl<N> TryFrom<ContainerInspectResponse> for LocalContainer<N> {
                 })
             })
             .unwrap_or_default();
+
+        let mut volumes = host_config
+            .as_mut()
+            .and_then(|hc| hc.mounts.take())
+            .unwrap_or_default()
+            .into_iter()
+            .map(Mount::try_from)
+            .collect::<Result<Vec<_>>>()?;
+
+        // Sort by target so the serialized form is stable regardless of the
+        // order the engine reports the mounts in — Mahler compares state via
+        // serialized JSON, so reordering must not trigger reconfiguration.
+        volumes.sort_by(|a, b| a.target().cmp(b.target()));
 
         let mut config = value.config;
         let labels = config
@@ -317,6 +334,7 @@ impl<N> TryFrom<ContainerInspectResponse> for LocalContainer<N> {
             restart_policy,
             networks,
             network_mode,
+            volumes,
         };
 
         let created: DateTime = value
@@ -502,6 +520,238 @@ impl std::fmt::Display for NetworkMode {
     }
 }
 
+/// Bind mount propagation mode. Mirrors the compose `bind.propagation` setting.
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum BindPropagation {
+    Private,
+    Rprivate,
+    Shared,
+    Rshared,
+    Slave,
+    Rslave,
+}
+
+impl From<BindPropagation> for MountBindOptionsPropagationEnum {
+    fn from(value: BindPropagation) -> Self {
+        match value {
+            BindPropagation::Private => Self::PRIVATE,
+            BindPropagation::Rprivate => Self::RPRIVATE,
+            BindPropagation::Shared => Self::SHARED,
+            BindPropagation::Rshared => Self::RSHARED,
+            BindPropagation::Slave => Self::SLAVE,
+            BindPropagation::Rslave => Self::RSLAVE,
+        }
+    }
+}
+
+impl TryFrom<MountBindOptionsPropagationEnum> for BindPropagation {
+    type Error = ();
+    fn try_from(value: MountBindOptionsPropagationEnum) -> std::result::Result<Self, Self::Error> {
+        Ok(match value {
+            MountBindOptionsPropagationEnum::PRIVATE => Self::Private,
+            MountBindOptionsPropagationEnum::RPRIVATE => Self::Rprivate,
+            MountBindOptionsPropagationEnum::SHARED => Self::Shared,
+            MountBindOptionsPropagationEnum::RSHARED => Self::Rshared,
+            MountBindOptionsPropagationEnum::SLAVE => Self::Slave,
+            MountBindOptionsPropagationEnum::RSLAVE => Self::Rslave,
+            MountBindOptionsPropagationEnum::EMPTY => return Err(()),
+        })
+    }
+}
+
+/// A container mount declared by the composition.
+///
+/// Three mount types are supported at the composition level: named volumes,
+/// host bind mounts, and tmpfs. A fourth variant, [`Mount::Other`], exists
+/// only for round-tripping container state: if the engine reports a mount
+/// type helios doesn't support (e.g. `image`, `npipe`, `cluster`), we
+/// preserve the target so that inspecting the container doesn't fail.
+/// Target-state flows never produce `Other`.
+///
+/// The `target` path inside the container is the unique identity of each
+/// mount within a `ContainerConfig`.
+#[serde_with::skip_serializing_none]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum Mount {
+    Volume {
+        /// Path inside the container where the volume is mounted
+        target: String,
+        /// Name of the volume (may be namespaced by the caller)
+        source: String,
+        #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+        read_only: bool,
+        /// Disable copying of data from the target path when the volume is created
+        #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+        nocopy: bool,
+        /// Subpath inside the volume to mount
+        subpath: Option<String>,
+    },
+    Bind {
+        target: String,
+        /// Host path to mount into the container
+        source: String,
+        #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+        read_only: bool,
+        propagation: Option<BindPropagation>,
+    },
+    Tmpfs {
+        target: String,
+        /// Size of the tmpfs in bytes
+        size: Option<i64>,
+        /// File mode for the tmpfs mount, encoded as Unix permission bits
+        mode: Option<u32>,
+    },
+    /// Placeholder for a mount type helios doesn't model (image, npipe, cluster).
+    /// Only produced when reading existing container state back from the engine.
+    Other {
+        target: String,
+        /// Raw mount type string as reported by the engine, retained for
+        /// diagnostics and so round-tripped state is stable.
+        kind: String,
+    },
+}
+
+impl Mount {
+    /// Container path this mount is bound to. Unique within a `ContainerConfig`.
+    pub fn target(&self) -> &str {
+        match self {
+            Self::Volume { target, .. } => target,
+            Self::Bind { target, .. } => target,
+            Self::Tmpfs { target, .. } => target,
+            Self::Other { target, .. } => target,
+        }
+    }
+}
+
+impl From<Mount> for bollard::models::Mount {
+    fn from(value: Mount) -> Self {
+        match value {
+            Mount::Volume {
+                target,
+                source,
+                read_only,
+                nocopy,
+                subpath,
+            } => {
+                let volume_options = if nocopy || subpath.is_some() {
+                    Some(MountVolumeOptions {
+                        no_copy: nocopy.then_some(true),
+                        subpath,
+                        ..Default::default()
+                    })
+                } else {
+                    None
+                };
+                bollard::models::Mount {
+                    typ: Some(MountTypeEnum::VOLUME),
+                    target: Some(target),
+                    source: Some(source),
+                    read_only: Some(read_only),
+                    volume_options,
+                    ..Default::default()
+                }
+            }
+            Mount::Bind {
+                target,
+                source,
+                read_only,
+                propagation,
+            } => {
+                let bind_options = propagation.map(|p| MountBindOptions {
+                    propagation: Some(p.into()),
+                    ..Default::default()
+                });
+                bollard::models::Mount {
+                    typ: Some(MountTypeEnum::BIND),
+                    target: Some(target),
+                    source: Some(source),
+                    read_only: Some(read_only),
+                    bind_options,
+                    ..Default::default()
+                }
+            }
+            Mount::Tmpfs { target, size, mode } => {
+                let tmpfs_options = if size.is_some() || mode.is_some() {
+                    Some(MountTmpfsOptions {
+                        size_bytes: size,
+                        mode: mode.map(|m| m as i64),
+                        ..Default::default()
+                    })
+                } else {
+                    None
+                };
+                bollard::models::Mount {
+                    typ: Some(MountTypeEnum::TMPFS),
+                    target: Some(target),
+                    tmpfs_options,
+                    ..Default::default()
+                }
+            }
+            // `Other` only comes from reading an existing container; it must
+            // never reach a create request. Panic to surface the programmer
+            // bug rather than silently sending a malformed Mount to the engine.
+            Mount::Other { target, kind } => {
+                unreachable!(
+                    "Mount::Other (kind='{kind}', target='{target}') cannot be written to the engine"
+                )
+            }
+        }
+    }
+}
+
+impl TryFrom<bollard::models::Mount> for Mount {
+    type Error = Error;
+
+    fn try_from(value: bollard::models::Mount) -> Result<Self> {
+        let target = value.target.ok_or("mount target is required")?;
+        let read_only = value.read_only.unwrap_or_default();
+        match value.typ {
+            Some(MountTypeEnum::VOLUME) => {
+                let source = value.source.unwrap_or_default();
+                let (nocopy, subpath) = value
+                    .volume_options
+                    .map(|o| (o.no_copy.unwrap_or_default(), o.subpath))
+                    .unwrap_or((false, None));
+                Ok(Mount::Volume {
+                    target,
+                    source,
+                    read_only,
+                    nocopy,
+                    subpath,
+                })
+            }
+            Some(MountTypeEnum::BIND) => {
+                let source = value.source.unwrap_or_default();
+                let propagation = value
+                    .bind_options
+                    .and_then(|o| o.propagation)
+                    .and_then(|p| BindPropagation::try_from(p).ok());
+                Ok(Mount::Bind {
+                    target,
+                    source,
+                    read_only,
+                    propagation,
+                })
+            }
+            Some(MountTypeEnum::TMPFS) => {
+                let (size, mode) = value
+                    .tmpfs_options
+                    .map(|o| (o.size_bytes, o.mode.map(|m| m as u32)))
+                    .unwrap_or((None, None));
+                Ok(Mount::Tmpfs { target, size, mode })
+            }
+            // Preserve unsupported mount types so that inspecting an existing
+            // container doesn't fail. Target-state flows never produce these.
+            other => Ok(Mount::Other {
+                target,
+                kind: other.map(|t| t.to_string()).unwrap_or_default(),
+            }),
+        }
+    }
+}
+
 /// Container configuration that is portable between hosts
 #[serde_with::skip_serializing_none]
 #[derive(Serialize, Deserialize, Debug, Clone, Eq, Default)]
@@ -529,9 +779,16 @@ pub struct ContainerConfig {
 
     /// Container network mode. When set, `networks` must be empty.
     pub network_mode: Option<NetworkMode>,
+
+    /// Filesystem mounts (volume, bind, tmpfs) indexed by target path.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub volumes: Vec<Mount>,
 }
 
-/// Compare configs treating networks as unordered (Docker inspect doesn't preserve priority order)
+/// Compare configs treating networks as unordered (Docker inspect doesn't
+/// preserve the network priority order). The volumes field is canonicalized
+/// (sorted by target path) on both deserialization paths so a straight Vec
+/// comparison is stable across target-state reorderings.
 impl PartialEq for ContainerConfig {
     fn eq(&self, other: &Self) -> bool {
         self.command == other.command
@@ -544,6 +801,7 @@ impl PartialEq for ContainerConfig {
                 .networks
                 .iter()
                 .all(|(k, v)| other.networks.get(k) == Some(v))
+            && self.volumes == other.volumes
     }
 }
 
@@ -556,6 +814,7 @@ impl From<ContainerConfig> for ContainerCreateBody {
             restart_policy,
             networks,
             network_mode,
+            volumes,
         } = value;
 
         let env = if environment.is_empty() {
@@ -610,9 +869,16 @@ impl From<ContainerConfig> for ContainerCreateBody {
             (host_network_mode, Some(networking_config))
         };
 
+        let engine_mounts = if volumes.is_empty() {
+            None
+        } else {
+            Some(volumes.into_iter().map(Into::into).collect())
+        };
+
         let host_config = bollard::config::HostConfig {
             network_mode: host_network_mode,
             restart_policy: Some(restart_policy),
+            mounts: engine_mounts,
             ..Default::default()
         };
 
@@ -648,5 +914,85 @@ impl<N: Namespace> LocalContainer<N> {
     /// Get the namepace from the local container metadata
     pub fn namespace(&self, service: &str) -> Option<N> {
         N::from_identifier(&self.name, service)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bollard::models::{HostConfig, Mount as EngineMount};
+
+    fn vol_mount(target: &str, source: &str) -> EngineMount {
+        EngineMount {
+            typ: Some(MountTypeEnum::VOLUME),
+            target: Some(target.to_string()),
+            source: Some(source.to_string()),
+            read_only: Some(false),
+            ..Default::default()
+        }
+    }
+
+    fn inspect_with_mounts(mounts: Vec<EngineMount>) -> ContainerInspectResponse {
+        ContainerInspectResponse {
+            id: Some("cid".to_string()),
+            name: Some("/svc".to_string()),
+            image: Some("img".to_string()),
+            created: Some("2026-01-01T00:00:00Z".to_string()),
+            host_config: Some(HostConfig {
+                mounts: Some(mounts),
+                ..Default::default()
+            }),
+            state: Some(bollard::models::ContainerState {
+                status: Some(ContainerStateStatusEnum::RUNNING),
+                ..Default::default()
+            }),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn inspect_sorts_volumes_by_target() {
+        let c: LocalContainer = inspect_with_mounts(vec![
+            vol_mount("/c", "vol-c"),
+            vol_mount("/a", "vol-a"),
+            vol_mount("/b", "vol-b"),
+        ])
+        .try_into()
+        .unwrap();
+        let targets: Vec<&str> = c.config.volumes.iter().map(|m| m.target()).collect();
+        assert_eq!(targets, vec!["/a", "/b", "/c"]);
+    }
+
+    #[test]
+    fn inspect_preserves_unsupported_mount_types_as_other() {
+        // An `image` mount on an existing container must not cause the inspect
+        // conversion to fail — it round-trips as `Mount::Other`.
+        let image_mount = EngineMount {
+            typ: Some(MountTypeEnum::IMAGE),
+            target: Some("/data".to_string()),
+            source: Some("some/image".to_string()),
+            ..Default::default()
+        };
+        let c: LocalContainer = inspect_with_mounts(vec![image_mount]).try_into().unwrap();
+        assert_eq!(c.config.volumes.len(), 1);
+        match &c.config.volumes[0] {
+            Mount::Other { target, kind } => {
+                assert_eq!(target, "/data");
+                assert_eq!(kind, "image");
+            }
+            other => panic!("expected Mount::Other, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn inspect_fails_on_missing_mount_target() {
+        let no_target = EngineMount {
+            typ: Some(MountTypeEnum::VOLUME),
+            target: None,
+            source: Some("vol".to_string()),
+            ..Default::default()
+        };
+        let result: Result<LocalContainer> = inspect_with_mounts(vec![no_target]).try_into();
+        assert!(result.is_err());
     }
 }

--- a/helios-oci/src/lib.rs
+++ b/helios-oci/src/lib.rs
@@ -13,8 +13,8 @@ pub use registry::RegistryAuth;
 
 mod container;
 pub use container::{
-    Container, ContainerConfig, ContainerState, ContainerStatus, LocalContainer, NetworkMode,
-    NetworkSettings, RestartPolicy,
+    BindPropagation, Container, ContainerConfig, ContainerState, ContainerStatus, LocalContainer,
+    Mount, NetworkMode, NetworkSettings, RestartPolicy,
 };
 
 mod datetime;

--- a/helios-remote-model/src/lib.rs
+++ b/helios-remote-model/src/lib.rs
@@ -272,6 +272,18 @@ impl<'de> Deserialize<'de> for Release {
                 }
             }
 
+            // Verify each volume-type mount references a volume declared at the release level.
+            for mount in svc.composition.volumes.iter() {
+                if let Mount::Volume(v) = mount
+                    && !raw.volumes.contains_key(&v.source)
+                {
+                    return Err(serde::de::Error::custom(format!(
+                        "service '{svc_name}' refers to undefined volume {}",
+                        v.source
+                    )));
+                }
+            }
+
             // Skip default-network injection when network_mode is set (host/none don't
             // participate in user-defined networks).
             if svc.composition.networks.is_empty() && svc.composition.network_mode.is_none() {
@@ -447,6 +459,50 @@ mod tests {
         assert_eq!(
             err.to_string(),
             "apps.?.releases.?.services.main.composition.networks.my-net.aliases: invalid type: string \"my-alias\", expected a sequence"
+        )
+    }
+
+    #[test]
+    fn test_rejects_target_service_with_invalid_volumes() {
+        let json = json!({
+            "name": "my-device",
+            "apps": {
+                "app-one": {
+                    "id": 1,
+                    "name": "my-app",
+                    "releases": {
+                        "c8b48659434e80a8b3adc0c5ad1e347a": {
+                            "id": 7,
+                            "services": {
+                                "main": {
+                                    "id": 3,
+                                    "image_id": 4,
+                                    "image": "registry2.balena-cloud.com/v2/8a961e0325a37441f33091743fa40a4c@sha256:0f3169ee8672222eb775b032cb3b2d06ef8eafa23a970643052bb67ac1fc5cd9",
+                                    "composition": {
+                                        "volumes": [
+                                            {
+                                                "type": "volume",
+                                                "source": "data",
+                                                "target": "/data",
+                                                "read_only": "yes"
+                                            }
+                                        ]
+                                    }
+                                }
+                            },
+                            "volumes": {
+                                "data": {}
+                            }
+                        }
+                    }
+                },
+            }
+        });
+
+        let err = serde_json::from_value::<Device>(json).unwrap_err();
+        assert_eq!(
+            err.to_string(),
+            "apps.?.releases.?.services.main.composition.volumes[0].read_only: invalid type: string \"yes\", expected a boolean"
         )
     }
 
@@ -640,5 +696,72 @@ mod tests {
         let default_net = &release.networks["default"];
         assert_eq!(default_net.driver, Some("overlay".to_string()));
         assert!(default_net.internal);
+    }
+
+    #[test]
+    fn test_release_accepts_service_with_volume_mount() {
+        let release: Release = serde_json::from_value(json!({
+            "services": {
+                "my-service": {
+                    "id": 1,
+                    "image": "ubuntu:latest",
+                    "composition": {
+                        "volumes": ["data:/var/data"]
+                    }
+                }
+            },
+            "volumes": {"data": {}},
+            "networks": {}
+        }))
+        .unwrap();
+
+        let svc = release.services.get("my-service").unwrap();
+        assert_eq!(svc.composition.volumes.iter().count(), 1);
+    }
+
+    #[test]
+    fn test_release_rejects_undefined_volume_reference() {
+        let err = serde_json::from_value::<Release>(json!({
+            "services": {
+                "my-service": {
+                    "id": 1,
+                    "image": "ubuntu:latest",
+                    "composition": {
+                        "volumes": ["missing:/data"]
+                    }
+                }
+            },
+            "volumes": {},
+            "networks": {}
+        }))
+        .unwrap_err();
+        assert_eq!(
+            err.to_string(),
+            "service 'my-service' refers to undefined volume missing"
+        );
+    }
+
+    #[test]
+    fn test_release_accepts_service_with_bind_and_tmpfs_mounts() {
+        let release: Release = serde_json::from_value(json!({
+            "services": {
+                "my-service": {
+                    "id": 1,
+                    "image": "ubuntu:latest",
+                    "composition": {
+                        "volumes": [
+                            "/etc/machine-id:/etc/machine-id",
+                            {"type": "tmpfs", "target": "/tmp"}
+                        ]
+                    }
+                }
+            },
+            "volumes": {},
+            "networks": {}
+        }))
+        .unwrap();
+
+        let svc = release.services.get("my-service").unwrap();
+        assert_eq!(svc.composition.volumes.iter().count(), 2);
     }
 }

--- a/helios-remote-model/src/service/mod.rs
+++ b/helios-remote-model/src/service/mod.rs
@@ -8,11 +8,13 @@ mod command;
 mod network_mode;
 mod networks;
 mod restart_policy;
+mod volumes;
 
 pub use command::*;
 pub use network_mode::*;
 pub use networks::*;
 pub use restart_policy::*;
+pub use volumes::*;
 
 use super::labels::Labels;
 
@@ -52,6 +54,9 @@ pub struct ServiceComposition {
 
     #[serde(default)]
     pub network_mode: Option<NetworkMode>,
+
+    #[serde(default)]
+    pub volumes: VolumesConfig,
 }
 
 #[cfg(test)]

--- a/helios-remote-model/src/service/volumes.rs
+++ b/helios-remote-model/src/service/volumes.rs
@@ -1,0 +1,533 @@
+//! Service mount configuration as defined by the Compose spec.
+//!
+//! The `volumes` field on a service is an array of mount specs, each of which
+//! is either a short-form string (`"src:dst"`, `"src:dst:ro"`) or a long-form
+//! object with a `type`. Supported types are `volume`, `bind`, and `tmpfs`.
+//!
+//! Bind mounts are restricted to a fixed allowlist of host paths so app
+//! services cannot arbitrarily mount the root filesystem.
+
+use serde::{
+    Deserialize, Deserializer,
+    de::{MapAccess, Visitor, value::MapAccessDeserializer},
+};
+use std::fmt;
+
+/// Bind mount propagation mode.
+#[derive(Deserialize, Clone, Debug, Copy, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum BindPropagation {
+    Private,
+    Rprivate,
+    Shared,
+    Rshared,
+    Slave,
+    Rslave,
+}
+
+/// Volume-type mount (references a named volume declared in the top-level `volumes`).
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct VolumeMount {
+    pub source: String,
+    pub target: String,
+    pub read_only: bool,
+    pub nocopy: bool,
+    pub subpath: Option<String>,
+}
+
+/// Bind-type mount (maps a host path into the container).
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct BindMount {
+    pub source: String,
+    pub target: String,
+    pub read_only: bool,
+    pub propagation: Option<BindPropagation>,
+}
+
+/// Tmpfs-type mount (in-memory filesystem).
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct TmpfsMount {
+    pub target: String,
+    pub size: Option<i64>,
+    pub mode: Option<u32>,
+}
+
+/// A single service mount entry.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum Mount {
+    Volume(VolumeMount),
+    Bind(BindMount),
+    Tmpfs(TmpfsMount),
+}
+
+impl Mount {
+    /// Container path this mount binds to.
+    pub fn target(&self) -> &str {
+        match self {
+            Mount::Volume(m) => &m.target,
+            Mount::Bind(m) => &m.target,
+            Mount::Tmpfs(m) => &m.target,
+        }
+    }
+}
+
+/// Host paths that are permitted as bind-mount sources, these are the
+/// same bind mounts allowed from labels
+const BIND_SOURCE_ALLOWLIST: &[&str] = &[
+    "/var/run/docker.sock",
+    "/run/dbus",
+    "/sys",
+    "/proc",
+    "/lib/modules",
+    "/lib/firmware",
+    "/var/log/journal",
+    "/run/log/journal",
+    "/etc/machine-id",
+];
+
+fn is_allowed_bind_source(source: &str) -> bool {
+    BIND_SOURCE_ALLOWLIST.contains(&source)
+}
+
+/// Service mount list.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct VolumesConfig(Vec<Mount>);
+
+impl VolumesConfig {
+    pub fn as_slice(&self) -> &[Mount] {
+        &self.0
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    pub fn iter(&self) -> std::slice::Iter<'_, Mount> {
+        self.0.iter()
+    }
+}
+
+impl IntoIterator for VolumesConfig {
+    type Item = Mount;
+    type IntoIter = std::vec::IntoIter<Mount>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.into_iter()
+    }
+}
+
+/// Long-form mount object used during deserialization.
+#[derive(Deserialize)]
+struct LongMount {
+    #[serde(rename = "type")]
+    kind: String,
+    #[serde(default)]
+    source: Option<String>,
+    target: String,
+    #[serde(default)]
+    read_only: bool,
+    #[serde(default)]
+    volume: Option<VolumeOptions>,
+    #[serde(default)]
+    bind: Option<BindOptions>,
+    #[serde(default)]
+    tmpfs: Option<TmpfsOptions>,
+}
+
+#[derive(Deserialize, Default)]
+#[serde(default)]
+struct VolumeOptions {
+    nocopy: bool,
+    subpath: Option<String>,
+}
+
+#[derive(Deserialize, Default)]
+#[serde(default)]
+struct BindOptions {
+    propagation: Option<BindPropagation>,
+}
+
+#[derive(Deserialize, Default)]
+#[serde(default)]
+struct TmpfsOptions {
+    size: Option<i64>,
+    mode: Option<u32>,
+}
+
+enum RawMount {
+    Short(String),
+    Long(LongMount),
+}
+
+// Custom Deserialize so that errors inside the long-form object preserve their
+// field path (e.g. `volumes[0].read_only`)
+impl<'de> Deserialize<'de> for RawMount {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct RawMountVisitor;
+
+        impl<'de> Visitor<'de> for RawMountVisitor {
+            type Value = RawMount;
+
+            fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {
+                f.write_str("a short-form mount string or long-form mount object")
+            }
+
+            fn visit_str<E: serde::de::Error>(self, v: &str) -> Result<Self::Value, E> {
+                Ok(RawMount::Short(v.to_string()))
+            }
+
+            fn visit_string<E: serde::de::Error>(self, v: String) -> Result<Self::Value, E> {
+                Ok(RawMount::Short(v))
+            }
+
+            fn visit_map<A: MapAccess<'de>>(self, map: A) -> Result<Self::Value, A::Error> {
+                LongMount::deserialize(MapAccessDeserializer::new(map)).map(RawMount::Long)
+            }
+        }
+
+        deserializer.deserialize_any(RawMountVisitor)
+    }
+}
+
+impl<'de> Deserialize<'de> for VolumesConfig {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let raw: Vec<RawMount> = Vec::deserialize(deserializer)?;
+        let mut mounts = Vec::with_capacity(raw.len());
+        for entry in raw {
+            mounts.push(parse_mount(entry).map_err(serde::de::Error::custom)?);
+        }
+        // Canonicalize by container-side target so the downstream serialized form
+        // is stable against reorderings in the remote composition.
+        mounts.sort_by(|a, b| a.target().cmp(b.target()));
+        Ok(VolumesConfig(mounts))
+    }
+}
+
+fn parse_mount(raw: RawMount) -> Result<Mount, String> {
+    match raw {
+        RawMount::Short(s) => parse_short(&s),
+        RawMount::Long(m) => parse_long(m),
+    }
+}
+
+fn parse_short(s: &str) -> Result<Mount, String> {
+    // `src:dst` or `src:dst:mode`
+    let parts: Vec<&str> = s.splitn(3, ':').collect();
+    if parts.len() < 2 {
+        return Err(format!(
+            "invalid short-form mount '{s}': expected `src:dst`"
+        ));
+    }
+    let source = parts[0];
+    let target = parts[1];
+    let mode = parts.get(2).copied().unwrap_or("");
+
+    if source.is_empty() || target.is_empty() {
+        return Err(format!("invalid short-form mount '{s}'"));
+    }
+
+    let mut read_only = false;
+    for token in mode.split(',').filter(|t| !t.is_empty()) {
+        match token {
+            "ro" => read_only = true,
+            "rw" => read_only = false,
+            // SELinux/other flags are ignored on platforms that don't enforce them;
+            // accept them silently for compatibility with the short-form spec.
+            "z" | "Z" => {}
+            other => {
+                return Err(format!(
+                    "unsupported short-form mount option '{other}' in '{s}'"
+                ));
+            }
+        }
+    }
+
+    // Host paths start with `/` or `.`; anything else is a named volume.
+    if source.starts_with('/') {
+        if !is_allowed_bind_source(source) {
+            return Err(format!(
+                "bind mount source '{source}' is not in the allowed list"
+            ));
+        }
+        Ok(Mount::Bind(BindMount {
+            source: source.to_string(),
+            target: target.to_string(),
+            read_only,
+            propagation: None,
+        }))
+    } else if source.starts_with('.') {
+        Err(format!(
+            "relative bind paths are not supported (got '{source}')"
+        ))
+    } else {
+        Ok(Mount::Volume(VolumeMount {
+            source: source.to_string(),
+            target: target.to_string(),
+            read_only,
+            nocopy: false,
+            subpath: None,
+        }))
+    }
+}
+
+fn parse_long(m: LongMount) -> Result<Mount, String> {
+    let LongMount {
+        kind,
+        source,
+        target,
+        read_only,
+        volume,
+        bind,
+        tmpfs,
+    } = m;
+
+    if target.is_empty() {
+        return Err("mount target cannot be empty".to_string());
+    }
+
+    match kind.as_str() {
+        "volume" => {
+            let source = source.ok_or_else(|| "volume mount requires a `source`".to_string())?;
+            let VolumeOptions { nocopy, subpath } = volume.unwrap_or_default();
+            Ok(Mount::Volume(VolumeMount {
+                source,
+                target,
+                read_only,
+                nocopy,
+                subpath,
+            }))
+        }
+        "bind" => {
+            let source = source.ok_or_else(|| "bind mount requires a `source`".to_string())?;
+            if !is_allowed_bind_source(&source) {
+                return Err(format!(
+                    "bind mount source '{source}' is not in the allowed list"
+                ));
+            }
+            let BindOptions { propagation } = bind.unwrap_or_default();
+            Ok(Mount::Bind(BindMount {
+                source,
+                target,
+                read_only,
+                propagation,
+            }))
+        }
+        "tmpfs" => {
+            let TmpfsOptions { size, mode } = tmpfs.unwrap_or_default();
+            Ok(Mount::Tmpfs(TmpfsMount { target, size, mode }))
+        }
+        "image" | "npipe" | "cluster" => Err(format!("mount type `{kind}` is not supported")),
+        other => Err(format!("unknown mount type `{other}`")),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn short_form_named_volume() {
+        let v: VolumesConfig = serde_json::from_value(json!(["my-vol:/data"])).unwrap();
+        assert_eq!(
+            v.as_slice(),
+            &[Mount::Volume(VolumeMount {
+                source: "my-vol".to_string(),
+                target: "/data".to_string(),
+                read_only: false,
+                nocopy: false,
+                subpath: None,
+            })]
+        );
+    }
+
+    #[test]
+    fn short_form_named_volume_readonly() {
+        let v: VolumesConfig = serde_json::from_value(json!(["my-vol:/data:ro"])).unwrap();
+        match &v.as_slice()[0] {
+            Mount::Volume(m) => assert!(m.read_only),
+            _ => panic!("expected volume mount"),
+        }
+    }
+
+    #[test]
+    fn short_form_allowed_bind() {
+        let v: VolumesConfig =
+            serde_json::from_value(json!(["/etc/machine-id:/etc/machine-id"])).unwrap();
+        assert_eq!(
+            v.as_slice(),
+            &[Mount::Bind(BindMount {
+                source: "/etc/machine-id".to_string(),
+                target: "/etc/machine-id".to_string(),
+                read_only: false,
+                propagation: None,
+            })]
+        );
+    }
+
+    #[test]
+    fn short_form_bind_not_in_allowlist_rejected() {
+        let err = serde_json::from_value::<VolumesConfig>(json!(["/root:/root"])).unwrap_err();
+        assert!(err.to_string().contains("not in the allowed list"));
+    }
+
+    #[test]
+    fn short_form_bind_allows_custom_target() {
+        // Allowlisted source + arbitrary target is permitted.
+        let v: VolumesConfig =
+            serde_json::from_value(json!(["/etc/machine-id:/app/machine-id:ro"])).unwrap();
+        assert_eq!(
+            v.as_slice(),
+            &[Mount::Bind(BindMount {
+                source: "/etc/machine-id".to_string(),
+                target: "/app/machine-id".to_string(),
+                read_only: true,
+                propagation: None,
+            })]
+        );
+    }
+
+    #[test]
+    fn short_form_relative_bind_rejected() {
+        let err = serde_json::from_value::<VolumesConfig>(json!(["./data:/data"])).unwrap_err();
+        assert!(err.to_string().contains("relative bind paths"));
+    }
+
+    #[test]
+    fn long_form_volume_with_options() {
+        let v: VolumesConfig = serde_json::from_value(json!([{
+            "type": "volume",
+            "source": "db-data",
+            "target": "/etc/data",
+            "read_only": true,
+            "volume": { "nocopy": true, "subpath": "sub" }
+        }]))
+        .unwrap();
+        assert_eq!(
+            v.as_slice(),
+            &[Mount::Volume(VolumeMount {
+                source: "db-data".to_string(),
+                target: "/etc/data".to_string(),
+                read_only: true,
+                nocopy: true,
+                subpath: Some("sub".to_string()),
+            })]
+        );
+    }
+
+    #[test]
+    fn long_form_bind_allowed() {
+        let v: VolumesConfig = serde_json::from_value(json!([{
+            "type": "bind",
+            "source": "/var/run/docker.sock",
+            "target": "/host/run/docker.sock"
+        }]))
+        .unwrap();
+        assert!(matches!(v.as_slice()[0], Mount::Bind(_)));
+    }
+
+    #[test]
+    fn long_form_bind_rejected_when_not_allowlisted() {
+        let err = serde_json::from_value::<VolumesConfig>(json!([{
+            "type": "bind",
+            "source": "/home/user",
+            "target": "/data"
+        }]))
+        .unwrap_err();
+        assert!(err.to_string().contains("not in the allowed list"));
+    }
+
+    #[test]
+    fn long_form_bind_allows_custom_target() {
+        let v: VolumesConfig = serde_json::from_value(json!([{
+            "type": "bind",
+            "source": "/proc",
+            "target": "/app/proc"
+        }]))
+        .unwrap();
+        match &v.as_slice()[0] {
+            Mount::Bind(b) => {
+                assert_eq!(b.source, "/proc");
+                assert_eq!(b.target, "/app/proc");
+            }
+            _ => panic!("expected bind mount"),
+        }
+    }
+
+    #[test]
+    fn long_form_tmpfs() {
+        let v: VolumesConfig = serde_json::from_value(json!([{
+            "type": "tmpfs",
+            "target": "/tmp",
+            "tmpfs": { "size": 65536, "mode": 448 }
+        }]))
+        .unwrap();
+        assert_eq!(
+            v.as_slice(),
+            &[Mount::Tmpfs(TmpfsMount {
+                target: "/tmp".to_string(),
+                size: Some(65536),
+                mode: Some(448),
+            })]
+        );
+    }
+
+    #[test]
+    fn long_form_image_rejected() {
+        let err = serde_json::from_value::<VolumesConfig>(json!([{
+            "type": "image",
+            "source": "some/image",
+            "target": "/data"
+        }]))
+        .unwrap_err();
+        assert!(err.to_string().contains("not supported"));
+    }
+
+    #[test]
+    fn long_form_npipe_rejected() {
+        let err = serde_json::from_value::<VolumesConfig>(json!([{
+            "type": "npipe",
+            "source": "foo",
+            "target": "/data"
+        }]))
+        .unwrap_err();
+        assert!(err.to_string().contains("not supported"));
+    }
+
+    #[test]
+    fn long_form_cluster_rejected() {
+        let err = serde_json::from_value::<VolumesConfig>(json!([{
+            "type": "cluster",
+            "source": "foo",
+            "target": "/data"
+        }]))
+        .unwrap_err();
+        assert!(err.to_string().contains("not supported"));
+    }
+
+    #[test]
+    fn empty_default() {
+        let v: VolumesConfig = serde_json::from_value(json!([])).unwrap();
+        assert!(v.is_empty());
+    }
+
+    #[test]
+    fn deserialize_sorts_by_target() {
+        // Deserialization canonicalizes by target so reordering in the remote
+        // composition does not propagate downstream.
+        let v: VolumesConfig = serde_json::from_value(json!([
+            "vol-c:/c",
+            {"type": "tmpfs", "target": "/a"},
+            "vol-b:/b",
+        ]))
+        .unwrap();
+        let targets: Vec<&str> = v.iter().map(|m| m.target()).collect();
+        assert_eq!(targets, vec!["/a", "/b", "/c"]);
+    }
+}

--- a/helios-state/src/models/service/config.rs
+++ b/helios-state/src/models/service/config.rs
@@ -6,7 +6,7 @@ use serde_json as json;
 
 use crate::common_types::Uuid;
 use crate::labels::{LABEL_APP_UUID, LABEL_SERVICE_ID, LABEL_SERVICE_NAME, LABEL_SUPERVISED};
-use crate::oci::{self, LocalNamespace, Namespace};
+use crate::oci::{self, LocalNamespace, Mount, Namespace};
 
 const LABEL_CONFIG_FIELDS: &str = "io.balena.private.config.fields";
 const LABEL_CONFIG_LABELS: &str = "io.balena.private.config.labels";
@@ -82,6 +82,13 @@ impl From<oci::ContainerConfig> for ServiceConfig {
                     (net_name, net_config)
                 })
                 .collect();
+
+            // De-namespace volume mount sources by stripping the app_uuid suffix
+            for mount in config.volumes.iter_mut() {
+                if let Mount::Volume { source, .. } = mount {
+                    *source = namespace.to_entity(source);
+                }
+            }
         }
 
         // Remove labels from the container that were not defined in
@@ -175,8 +182,16 @@ impl ServiceConfig {
         labels.insert(LABEL_SERVICE_NAME.to_string(), svc_name.to_string());
         labels.insert(LABEL_SERVICE_ID.to_string(), svc_id.to_string());
 
-        let networks = std::mem::take(&mut config.networks);
         let namespace = LocalNamespace::from(app_uuid.as_str());
+
+        // Namespace volume mount sources so they match the volumes created under the app
+        for mount in config.volumes.iter_mut() {
+            if let Mount::Volume { source, .. } = mount {
+                *source = namespace.to_identifier(source);
+            }
+        }
+
+        let networks = std::mem::take(&mut config.networks);
         for (net_name, mut net_config) in networks {
             // store the target aliases into a label as the engine may insert new aliases
             // that we want to remove when reading the container state

--- a/helios-state/src/models/service/mod.rs
+++ b/helios-state/src/models/service/mod.rs
@@ -3,9 +3,11 @@ use serde::{Deserialize, Serialize};
 
 use crate::labels::LABEL_SERVICE_ID;
 use crate::oci::{
-    self, ContainerConfig, DateTime, LocalContainer, NetworkMode, NetworkSettings, RestartPolicy,
+    self, BindPropagation, ContainerConfig, DateTime, LocalContainer, Mount, NetworkMode,
+    NetworkSettings, RestartPolicy,
 };
 use crate::remote_model::{
+    BindPropagation as RemoteBindPropagation, Mount as RemoteMount,
     NetworkMode as RemoteNetworkMode, RestartPolicy as RemoteRestartPolicy,
     Service as RemoteServiceTarget,
 };
@@ -184,6 +186,41 @@ impl From<RemoteServiceTarget> for ServiceTarget {
             RemoteNetworkMode::Bridge => NetworkMode::Other("bridge".to_string()),
         });
 
+        // Convert the service mounts. The composition `volumes` arrive already
+        // canonicalized (sorted by target) from the remote-model deserializer,
+        // so no further sorting is required here.
+        let volumes: Vec<Mount> = composition
+            .volumes
+            .into_iter()
+            .map(|m| match m {
+                RemoteMount::Volume(v) => Mount::Volume {
+                    target: v.target,
+                    source: v.source,
+                    read_only: v.read_only,
+                    nocopy: v.nocopy,
+                    subpath: v.subpath,
+                },
+                RemoteMount::Bind(b) => Mount::Bind {
+                    target: b.target,
+                    source: b.source,
+                    read_only: b.read_only,
+                    propagation: b.propagation.map(|p| match p {
+                        RemoteBindPropagation::Private => BindPropagation::Private,
+                        RemoteBindPropagation::Rprivate => BindPropagation::Rprivate,
+                        RemoteBindPropagation::Shared => BindPropagation::Shared,
+                        RemoteBindPropagation::Rshared => BindPropagation::Rshared,
+                        RemoteBindPropagation::Slave => BindPropagation::Slave,
+                        RemoteBindPropagation::Rslave => BindPropagation::Rslave,
+                    }),
+                },
+                RemoteMount::Tmpfs(t) => Mount::Tmpfs {
+                    target: t.target,
+                    size: t.size,
+                    mode: t.mode,
+                },
+            })
+            .collect();
+
         ServiceTarget {
             id,
             image: image.into(),
@@ -195,6 +232,7 @@ impl From<RemoteServiceTarget> for ServiceTarget {
                 restart_policy,
                 networks,
                 network_mode,
+                volumes,
             }),
         }
     }

--- a/helios-state/src/tasks/app.rs
+++ b/helios-state/src/tasks/app.rs
@@ -11,7 +11,7 @@ use crate::models::{
 };
 use crate::store::{self, DocumentStore};
 
-use crate::oci::{Client as Docker, Error as OciError, WithContext};
+use crate::oci::{Client as Docker, Error as OciError, Mount, WithContext};
 
 use super::image::create_image;
 use super::utils::{
@@ -424,12 +424,59 @@ fn create_volume(
 
 /// Reconfigure a volume by uninstalling it when the config has changed
 ///
-/// After uninstall, the planner will re-create the volume with the new config.
-fn reconfigure_volume(vol: View<Volume>, Target(tgt): Target<Volume>) -> Option<Task> {
+/// Services referencing the volume that already have a container are torn down
+/// first; the planner will then uninstall and re-create the volume, and
+/// re-install the services on the next cycle.
+fn reconfigure_volume(
+    vol: View<Volume>,
+    System(device): System<Device>,
+    Target(tgt): Target<Volume>,
+    Args((app_uuid, _, vol_name)): Args<(Uuid, Uuid, String)>,
+) -> Vec<Task> {
     if vol.config != tgt.config {
-        Some(uninstall_volume.into_task())
+        let mut tasks = Vec::new();
+        let services_depending_on_volume = device
+            .apps
+            .get(&app_uuid)
+            .map(|app| {
+                app.releases
+                    .iter()
+                    .flat_map(|(rel_uuid, rel)| {
+                        rel.services
+                            .iter()
+                            .filter(|(_, svc)| {
+                                svc.oci.is_some()
+                                    && svc.config.volumes.iter().any(|m| {
+                                        matches!(m, Mount::Volume { source, .. }
+                                            if source == &vol_name)
+                                    })
+                            })
+                            .map(move |(svc_name, _)| (rel_uuid, svc_name))
+                    })
+                    .collect::<Vec<(&Uuid, &String)>>()
+            })
+            .unwrap_or_default();
+
+        for (rel_uuid, svc_name) in services_depending_on_volume {
+            tasks.push(
+                stop_service_when_requirements_are_met
+                    .with_arg("commit", rel_uuid.as_str())
+                    .with_arg("service_name", svc_name),
+            );
+            tasks.push(
+                remove_service_container
+                    .with_arg("commit", rel_uuid.as_str())
+                    .with_arg("service_name", svc_name),
+            );
+        }
+
+        if tasks.is_empty() {
+            tasks.push(uninstall_volume.into_task());
+        }
+
+        tasks
     } else {
-        None
+        Vec::new()
     }
 }
 
@@ -529,7 +576,23 @@ fn remove_volume_when_requirements_are_met(
         // State-only removal, Docker volume preserved for new release to adopt
         Some(remove_volume.into_task())
     } else {
-        Some(uninstall_volume.into_task())
+        let services_depend_on_volume = device.apps.get(&app_uuid).is_some_and(|app| {
+            app.releases.values().any(|rel| {
+                rel.services.values().any(|svc| {
+                    svc.config
+                        .volumes
+                        .iter()
+                        .any(|m| matches!(m, Mount::Volume { source, .. } if source == &vol_name))
+                })
+            })
+        });
+
+        // Cannot uninstall a volume that has dependent services on any installed release
+        if !services_depend_on_volume {
+            Some(uninstall_volume.into_task())
+        } else {
+            None
+        }
     }
 }
 
@@ -609,18 +672,18 @@ fn install_service_when_requirements_are_met(
         return None;
     }
 
+    let release = device
+        .apps
+        .get(&app_uuid)
+        .and_then(|app| app.releases.get(&rel_uuid));
+
+    let t_release = tgt_device
+        .apps
+        .get(&app_uuid)
+        .and_then(|app| app.releases.get(&rel_uuid));
+
     // Check that all required networks have been created in the release
     let networks_ready = if !tgt.config.networks.is_empty() {
-        let release = device
-            .apps
-            .get(&app_uuid)
-            .and_then(|app| app.releases.get(&rel_uuid));
-
-        let t_release = tgt_device
-            .apps
-            .get(&app_uuid)
-            .and_then(|app| app.releases.get(&rel_uuid));
-
         release.is_some_and(|release| {
             // for every configured network
             tgt.config.networks.keys().all(|net_name| {
@@ -640,11 +703,38 @@ fn install_service_when_requirements_are_met(
         true
     };
 
+    // Check that every volume referenced by a mount has been created with the right config
+    let tgt_volume_sources: Vec<&str> = tgt
+        .config
+        .volumes
+        .iter()
+        .filter_map(|m| match m {
+            Mount::Volume { source, .. } => Some(source.as_str()),
+            _ => None,
+        })
+        .collect();
+    let volumes_ready = if tgt_volume_sources.is_empty() {
+        true
+    } else {
+        release.is_some_and(|release| {
+            tgt_volume_sources.iter().all(|vol_name| {
+                if let Some(vol) = release.volumes.get(*vol_name)
+                    && let Some(t_vol) = t_release.and_then(|t_rel| t_rel.volumes.get(*vol_name))
+                    && vol.config == t_vol.config
+                {
+                    return true;
+                }
+                false
+            })
+        })
+    };
+
     // Skip the task if the image for the service doesn't exist yet
     // or there is an identically named service with the same image and
     // config. In the last scenario, the service will be created by the `uninstall_service`
     // operation
     if networks_ready
+        && volumes_ready
         && let ImageRef::Uri(tgt_img) = &tgt.image
         && device.images.contains_key(tgt_img)
         && find_installed_service(&device, &app_uuid, &rel_uuid, &svc_name)

--- a/helios-state/src/worker/tests/volumes.rs
+++ b/helios-state/src/worker/tests/volumes.rs
@@ -215,6 +215,233 @@ fn it_finds_a_workflow_for_updating_volumes() {
 }
 
 #[test]
+fn it_finds_a_workflow_to_install_a_service_with_a_volume_mount() {
+    init_tracing();
+    assert_workflow(
+        json!({
+            "uuid": "my-device-uuid",
+            "apps": {
+                "my-app-uuid": {
+                    "id": 1,
+                    "name": "my-app",
+                }
+            },
+        }),
+        json!({
+            "uuid": "my-device-uuid",
+            "apps": {
+                "my-app-uuid": {
+                    "id": 1,
+                    "name": "my-app",
+                    "releases": {
+                        "my-release-uuid": {
+                            "installed": true,
+                            "services": {
+                                "my-service": {
+                                    "id": 1,
+                                    "started": true,
+                                    "image": "ubuntu:latest",
+                                    "config": {
+                                        "volumes": [
+                                            {
+                                                "type": "volume",
+                                                "source": "my-volume",
+                                                "target": "/data"
+                                            }
+                                        ]
+                                    },
+                                },
+                            },
+                            "volumes": {
+                                "my-volume": {},
+                            },
+                        }
+                    }
+                }
+            },
+        }),
+        // Service references `my-volume`, so `setup volume` must complete before
+        // the service install.
+        seq!("initialize release 'my-release-uuid' for app with uuid 'my-app-uuid'")
+            + par!(
+                "initialize service 'my-service' for release 'my-release-uuid'",
+                "setup volume 'my-volume' for app 'my-app-uuid'",
+            )
+            + seq!(
+                "pull image 'ubuntu:latest'",
+                "install service 'my-service' for release 'my-release-uuid'",
+                "start service 'my-service' for release 'my-release-uuid'",
+                "finish release 'my-release-uuid' for app with uuid 'my-app-uuid'",
+            ),
+    );
+}
+
+#[test]
+fn it_finds_a_workflow_for_updating_a_volume_in_use_by_a_service() {
+    init_tracing();
+    assert_workflow(
+        json!({
+            "uuid": "my-device-uuid",
+            "apps": {
+                "my-app-uuid": {
+                    "id": 1,
+                    "name": "my-app",
+                    "releases": {
+                        "my-release-uuid": {
+                            "installed": true,
+                            "services": {
+                                "my-service": {
+                                    "id": 1,
+                                    "image": "ubuntu:latest",
+                                    "started": true,
+                                    "oci": running_container("my-release-uuid_my-service"),
+                                    "config": {
+                                        "volumes": [
+                                            {
+                                                "type": "volume",
+                                                "source": "my-volume",
+                                                "target": "/data"
+                                            }
+                                        ]
+                                    },
+                                },
+                            },
+                            "volumes": {
+                                "my-volume": {
+                                    "oci_name": "my-app-uuid_my-volume",
+                                    "config": {
+                                        "driver": "local",
+                                    },
+                                },
+                            },
+                        }
+                    }
+                }
+            },
+            "images": {
+                "ubuntu:latest" : {
+                    "oci_id": "abcde",
+                    "download_progress": 100,
+                }
+            }
+        }),
+        json!({
+            "uuid": "my-device-uuid",
+            "apps": {
+                "my-app-uuid": {
+                    "id": 1,
+                    "name": "my-app",
+                    "releases": {
+                        "my-release-uuid": {
+                            "installed": true,
+                            "services": {
+                                "my-service": {
+                                    "id": 1,
+                                    "image": "ubuntu:latest",
+                                    "started": true,
+                                    "config": {
+                                        "volumes": [
+                                            {
+                                                "type": "volume",
+                                                "source": "my-volume",
+                                                "target": "/data"
+                                            }
+                                        ]
+                                    },
+                                },
+                            },
+                            "volumes": {
+                                "my-volume": {
+                                    "config": {
+                                        "driver": "local",
+                                        "driver_opts": {
+                                            "type": "nfs",
+                                            "o": "addr=10.0.0.1,rw",
+                                            "device": ":/export/data"
+                                        },
+                                    },
+                                },
+                            },
+                        }
+                    }
+                }
+            },
+        }),
+        release_update(
+            "my-release-uuid",
+            "my-app-uuid",
+            seq!(
+                "stop service 'my-service' for release 'my-release-uuid'",
+                "remove container for service 'my-service' for release 'my-release-uuid'",
+                "remove volume 'my-volume' for app 'my-app-uuid'",
+                "setup volume 'my-volume' for app 'my-app-uuid'",
+                "install service 'my-service' for release 'my-release-uuid'",
+                "start service 'my-service' for release 'my-release-uuid'",
+            ),
+        ),
+    );
+}
+
+#[test]
+fn it_finds_a_workflow_to_install_a_service_with_bind_and_tmpfs_mounts() {
+    init_tracing();
+    assert_workflow(
+        json!({
+            "uuid": "my-device-uuid",
+            "apps": {
+                "my-app-uuid": {
+                    "id": 1,
+                    "name": "my-app",
+                }
+            },
+        }),
+        json!({
+            "uuid": "my-device-uuid",
+            "apps": {
+                "my-app-uuid": {
+                    "id": 1,
+                    "name": "my-app",
+                    "releases": {
+                        "my-release-uuid": {
+                            "installed": true,
+                            "services": {
+                                "my-service": {
+                                    "id": 1,
+                                    "started": true,
+                                    "image": "ubuntu:latest",
+                                    "config": {
+                                        "volumes": [
+                                            {
+                                                "type": "bind",
+                                                "source": "/etc/machine-id",
+                                                "target": "/etc/machine-id"
+                                            },
+                                            {
+                                                "type": "tmpfs",
+                                                "target": "/tmp"
+                                            }
+                                        ]
+                                    },
+                                },
+                            },
+                        }
+                    }
+                }
+            },
+        }),
+        // No top-level volumes are referenced, so there is no setup-volume step.
+        seq!(
+            "initialize release 'my-release-uuid' for app with uuid 'my-app-uuid'",
+            "initialize service 'my-service' for release 'my-release-uuid'",
+            "pull image 'ubuntu:latest'",
+            "install service 'my-service' for release 'my-release-uuid'",
+            "start service 'my-service' for release 'my-release-uuid'",
+            "finish release 'my-release-uuid' for app with uuid 'my-app-uuid'",
+        ),
+    );
+}
+
+#[test]
 fn it_finds_a_workflow_to_create_multiple_volumes_and_finalizes_release_after_volume_create() {
     init_tracing();
     assert_workflow(


### PR DESCRIPTION
Support for mounts of type `bind`, `volume` and `tmpfs` is included. Only bind-mounts from an allow-list (given by what's supported by labels) are allowed when de-serializing the target state.s

Depends-on: #104
Change-type: patch