### PR TITLE
Fix supervisor takeover script

### DIFF
--- a/helios-store/src/document.rs
+++ b/helios-store/src/document.rs
@@ -1141,10 +1141,11 @@ mod tests {
         );
 
         // list_at with a pattern scoped to the base
-        let paths = store
+        let mut paths = store
             .list_at(Some(Path::new("a")), Some("*.json"))
             .await
             .unwrap();
+        paths.sort();
         assert_eq!(
             paths,
             vec![PathBuf::from("1.json"), PathBuf::from("2.json")]

--- a/scripts/setup-supervisor.sh
+++ b/scripts/setup-supervisor.sh
@@ -42,7 +42,8 @@ wait_for_port_release() {
 }
 
 find_docker_image() {
-  docker inspect "$1" 2>/dev/null | jq -r '.[].Image'
+  img=$(docker inspect "$1" 2>/dev/null | jq -r '.[].Image')
+  [ -n "$img" ] && echo "$img"
 }
 
 find_db_dir() {


### PR DESCRIPTION
It was failing with older OS versions that still use resin_supervisor as a container. The script was not falling back to `resin_supervisor` when inspecting the containe

Includes a fix for a flaky test without which the PR cannot be merged

Change-type: patch