### PR TITLE
Fix issues with planning of operations around networks/volumes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -71,7 +71,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -82,7 +82,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -219,7 +219,7 @@ dependencies = [
  "hyper",
  "hyper-util",
  "itoa",
- "matchit",
+ "matchit 0.8.4",
  "memchr",
  "mime",
  "percent-encoding",
@@ -267,18 +267,18 @@ checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
 name = "block-buffer"
-version = "0.10.4"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
 dependencies = [
- "generic-array",
+ "hybrid-array",
 ]
 
 [[package]]
 name = "bollard"
-version = "0.20.2"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee04c4c84f1f811b017f2fbb7dd8815c976e7ca98593de9c1e2afad0f636bff4"
+checksum = "c9d0a013e3d3ee4edd61e779adf117944c08902d375f18630a0c5b8f95659734"
 dependencies = [
  "base64",
  "bollard-stubs",
@@ -308,9 +308,9 @@ dependencies = [
 
 [[package]]
 name = "bollard-stubs"
-version = "1.52.1-rc.29.1.3"
+version = "1.53.1-rc.29.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f0a8ca8799131c1837d1282c3f81f31e76ceb0ce426e04a7fe1ccee3287c066"
+checksum = "ce412eb6f7096743011dc3cb5c674caeb24ced61d8c498fe07cf7998a4fea889"
 dependencies = [
  "serde",
  "serde_json",
@@ -397,7 +397,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.3.0",
+ "cpufeatures",
  "rand_core 0.10.0",
 ]
 
@@ -518,15 +518,6 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "cpufeatures"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
@@ -542,12 +533,11 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crypto-common"
-version = "0.1.7"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
 dependencies = [
- "generic-array",
- "typenum",
+ "hybrid-array",
 ]
 
 [[package]]
@@ -592,9 +582,9 @@ checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
 
 [[package]]
 name = "digest"
-version = "0.10.7"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
  "block-buffer",
  "crypto-common",
@@ -618,7 +608,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -678,7 +668,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -851,16 +841,6 @@ dependencies = [
  "memchr",
  "pin-project-lite",
  "slab",
-]
-
-[[package]]
-name = "generic-array"
-version = "0.14.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
-dependencies = [
- "typenum",
- "version_check",
 ]
 
 [[package]]
@@ -1178,6 +1158,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
+name = "hybrid-array"
+version = "0.4.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d46837a0ed51fe95bd3b05de33cd64a1ee88fc797477ca48446872504507c5"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
 name = "hyper"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1271,12 +1260,13 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
 dependencies = [
  "displaydoc",
  "potential_utf",
+ "utf8_iter",
  "yoke",
  "zerofrom",
  "zerovec",
@@ -1284,9 +1274,9 @@ dependencies = [
 
 [[package]]
 name = "icu_locale_core"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -1297,9 +1287,9 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
 dependencies = [
  "icu_collections",
  "icu_normalizer_data",
@@ -1311,15 +1301,15 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer_data"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
 
 [[package]]
 name = "icu_properties"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
 dependencies = [
  "icu_collections",
  "icu_locale_core",
@@ -1331,15 +1321,15 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
 
 [[package]]
 name = "icu_provider"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
@@ -1402,16 +1392,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
-name = "iri-string"
-version = "0.7.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8e7418f59cc01c88316161279a7f665217ae316b388e58a0d10e29f54f1e5eb"
-dependencies = [
- "memchr",
- "serde",
-]
-
-[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1467,14 +1447,14 @@ dependencies = [
 
 [[package]]
 name = "json-patch"
-version = "4.1.0"
+version = "4.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f300e415e2134745ef75f04562dd0145405c2f7fd92065db029ac4b16b57fe90"
+checksum = "7421438de105a0827e44fadd05377727847d717c80ce29a229f85fd04c427b72"
 dependencies = [
  "jsonptr",
  "serde",
  "serde_json",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -1525,9 +1505,9 @@ checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "log"
@@ -1543,9 +1523,9 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "mahler"
-version = "0.25.9"
+version = "0.25.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07dcb47a0b9ce91692aba1888718bd6708b9274e88f53a2b8a7245a6dfb3d293"
+checksum = "e3e75209ebadc0d517f76d4a650614db768483f5c8bc565e4bca37083868f5ba"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -1553,7 +1533,7 @@ dependencies = [
  "jsonptr",
  "mahler-core",
  "mahler-derive",
- "matchit",
+ "matchit 0.9.2",
  "serde_json",
  "tokio",
  "tokio-stream",
@@ -1562,15 +1542,15 @@ dependencies = [
 
 [[package]]
 name = "mahler-core"
-version = "0.25.9"
+version = "0.25.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aca54c1d13e020177fa37e0d2dde74bc8c247f5d1e04b18f309a62e0370dd196"
+checksum = "36747dbb67649e28d31af55959db2bc250e139b7d8e437839669af32c5d0ed97"
 dependencies = [
  "async-trait",
  "futures",
  "json-patch",
  "jsonptr",
- "matchit",
+ "matchit 0.9.2",
  "serde_core",
  "serde_json",
  "tokio",
@@ -1578,9 +1558,9 @@ dependencies = [
 
 [[package]]
 name = "mahler-derive"
-version = "0.25.9"
+version = "0.25.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4849b3270455406c4f86947bd3762a9b5df47f28636f7441acf4f624cde8648b"
+checksum = "cfcb4292999b8e7c3ad67d881c244a243a2c222d091b896b03aa7e6947d6f979"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1601,6 +1581,12 @@ name = "matchit"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
+
+[[package]]
+name = "matchit"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8863b587001c1b9a8a4e36008cebc6b3612cb1226fe2de94858e06092687b608"
 
 [[package]]
 name = "memchr"
@@ -1664,7 +1650,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1742,9 +1728,9 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "potential_utf"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
  "zerovec",
 ]
@@ -2044,7 +2030,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2101,7 +2087,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2260,9 +2246,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.18.0"
+version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd5414fad8e6907dbdd5bc441a50ae8d6e26151a03b1de04d89a5576de61d01f"
+checksum = "f05839ce67618e14a09b286535c0d9c94e85ef25469b0e13cb4f844e5593eb19"
 dependencies = [
  "serde_core",
  "serde_with_macros",
@@ -2270,9 +2256,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.18.0"
+version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3db8978e608f1fe7357e211969fd9abdcae80bac1ba7a3369bb7eb6b404eb65"
+checksum = "cf2ebbe86054f9b45bc3881e865683ccfaccce97b9b4cb53f3039d67f355a334"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -2282,12 +2268,12 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.10.9"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.2.17",
+ "cpufeatures",
  "digest",
 ]
 
@@ -2347,7 +2333,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2420,7 +2406,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2474,9 +2460,9 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 dependencies = [
  "displaydoc",
  "zerovec",
@@ -2607,9 +2593,9 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.8"
+version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
+checksum = "a28f0d049ccfaa566e14e9663d304d8577427b368cb4710a20528690287a738b"
 dependencies = [
  "async-compression",
  "bitflags",
@@ -2619,7 +2605,6 @@ dependencies = [
  "http",
  "http-body",
  "http-body-util",
- "iri-string",
  "pin-project-lite",
  "tokio",
  "tokio-util",
@@ -2627,6 +2612,7 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
+ "url",
 ]
 
 [[package]]
@@ -2710,9 +2696,9 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "typenum"
-version = "1.19.0"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
 name = "uds_windows"
@@ -2784,12 +2770,6 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
-
-[[package]]
-name = "version_check"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "walkdir"
@@ -2991,7 +2971,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3327,9 +3307,9 @@ dependencies = [
 
 [[package]]
 name = "writeable"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "xattr"
@@ -3349,9 +3329,9 @@ checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "yoke"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
+checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",
@@ -3360,9 +3340,9 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3448,18 +3428,18 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
 dependencies = [
  "zerofrom-derive",
 ]
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3475,9 +3455,9 @@ checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 
 [[package]]
 name = "zerotrie"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
 dependencies = [
  "displaydoc",
  "yoke",
@@ -3486,9 +3466,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.5"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -3497,9 +3477,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,17 @@
 [workspace]
 resolver = "3"
-members = [ "helios", "helios-api", "helios-balenahup", "helios-legacy", "helios-oci", "helios-remote", "helios-remote-model", "helios-state", "helios-store", "helios-util" ]
+members = [
+  "helios",
+  "helios-api",
+  "helios-balenahup",
+  "helios-legacy",
+  "helios-oci",
+  "helios-remote",
+  "helios-remote-model",
+  "helios-state",
+  "helios-store",
+  "helios-util",
+]
 
 [workspace.package]
 version = "0.23.2"
@@ -9,7 +20,7 @@ edition = "2024"
 description = "Balena's on-device agent"
 homepage = "https://github.com/balena-io/helios"
 repository = "https://github.com/balena-io/helios"
-authors = [ "Balena Inc. <hello@balena.io>" ]
+authors = ["Balena Inc. <hello@balena.io>"]
 license = "Apache-2.0"
 readme = "README.md"
 publish = false
@@ -22,7 +33,7 @@ serde_json = "1.0"
 thiserror = "2"
 rand = "0.10.1"
 dirs = "6.0.0"
-bollard = "0.20"
+bollard = "0.21"
 fastrand = "2.4.1"
 regex = "1.12"
 pretty_assertions = "1.4.1"
@@ -73,17 +84,17 @@ default-features = false
 [workspace.dependencies.axum]
 version = "0.8.9"
 default-features = false
-features = [ "tokio", "http1", "json", "query" ]
+features = ["tokio", "http1", "json", "query"]
 
 [workspace.dependencies.chrono]
 version = "0.4"
 default-features = false
-features = [ "alloc", "core-error" ]
+features = ["alloc", "core-error"]
 
 [workspace.dependencies.getrandom]
 version = "0.4"
 default-features = false
-features = [ "std" ]
+features = ["std"]
 
 [workspace.dependencies.tempfile]
 version = "3"
@@ -92,48 +103,48 @@ default-features = false
 [workspace.dependencies.tokio]
 version = "1.52"
 default-features = false
-features = [ "time", "fs" ]
+features = ["time", "fs"]
 
 [workspace.dependencies.tokio-stream]
 version = "0.1.18"
 default-features = false
 
 [workspace.dependencies.tower-http]
-version = "0.6.8"
+version = "0.6.9"
 default-features = false
-features = [ "trace" ]
+features = ["trace"]
 
 [workspace.dependencies.tracing-subscriber]
 version = "0.3.23"
-features = [ "env-filter", "fmt", "registry", "ansi" ]
+features = ["env-filter", "fmt", "registry", "ansi"]
 
 [workspace.dependencies.reqwest]
 version = "0.13"
 default-features = false
-features = [ "json", "rustls", "brotli", "stream" ]
+features = ["json", "rustls", "brotli", "stream"]
 
 [workspace.dependencies.serde]
 version = "1.0"
-features = [ "derive" ]
+features = ["derive"]
 
 [workspace.dependencies.serde_with]
-version = "3.18"
+version = "3.19"
 default-features = false
-features = [ "macros" ]
+features = ["macros"]
 
 [workspace.dependencies.clap]
 version = "4.6"
-features = [ "derive", "env" ]
+features = ["derive", "env"]
 
 [workspace.dependencies.uuid]
 version = "1.23"
-features = [ "v4" ]
+features = ["v4"]
 
 [workspace.dependencies.mahler]
 version = "0.25"
 
 [workspace.dependencies.sha2]
-version = "0.10"
+version = "0.11"
 default-features = false
 
 [workspace.dependencies.mockito]
@@ -142,7 +153,7 @@ default-features = false
 
 [workspace.dependencies.indexmap]
 version = "2"
-features = [ "serde" ]
+features = ["serde"]
 
 [workspace.dependencies.globset]
 version = "0.4"
@@ -155,7 +166,7 @@ default-features = false
 [workspace.dependencies.zbus]
 version = "5.15"
 default-features = false
-features = [ "tokio" ]
+features = ["tokio"]
 
 [profile.release]
 opt-level = "z"

--- a/helios-integration-tests/Cargo.lock
+++ b/helios-integration-tests/Cargo.lock
@@ -13,9 +13,9 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
 dependencies = [
  "memchr",
 ]
@@ -33,21 +33,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94fb8275041c72129eb51b7d0322c29b8387a0386127718b096429201a5d6ece"
 dependencies = [
  "alloc-no-stdlib",
-]
-
-[[package]]
-name = "android-tzdata"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
-
-[[package]]
-name = "android_system_properties"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
-dependencies = [
- "libc",
 ]
 
 [[package]]
@@ -172,9 +157,9 @@ dependencies = [
 
 [[package]]
 name = "axum"
-version = "0.8.6"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a18ed336352031311f4e0b4dd2ff392d4fbb370777c9d18d7fc9d7359f73871"
+checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
 dependencies = [
  "axum-core",
  "bytes",
@@ -204,9 +189,9 @@ dependencies = [
 
 [[package]]
 name = "axum-core"
-version = "0.5.5"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59446ce19cd142f8833f856eb31f3eb097812d1479ab224f54d72428ca21ea22"
+checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
 dependencies = [
  "bytes",
  "futures-core",
@@ -248,24 +233,24 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "2.9.1"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
+checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
 name = "block-buffer"
-version = "0.10.4"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
 dependencies = [
- "generic-array",
+ "hybrid-array",
 ]
 
 [[package]]
 name = "bollard"
-version = "0.20.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6ae2b41d5596b7b0db9942973d7da42109f2abaa34aa929a2d5362a38fb37ce"
+checksum = "c9d0a013e3d3ee4edd61e779adf117944c08902d375f18630a0c5b8f95659734"
 dependencies = [
  "base64",
  "bollard-stubs",
@@ -284,7 +269,6 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "serde_repr",
  "serde_urlencoded",
  "thiserror 2.0.16",
  "tokio",
@@ -296,14 +280,13 @@ dependencies = [
 
 [[package]]
 name = "bollard-stubs"
-version = "1.52.0-rc.29.1.3"
+version = "1.53.1-rc.29.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712904cb6b941e87a6f00f330132daedb6b4054d140547876e06dbac6f1e55e7"
+checksum = "ce412eb6f7096743011dc3cb5c674caeb24ced61d8c498fe07cf7998a4fea889"
 dependencies = [
  "serde",
  "serde_json",
  "serde_repr",
- "serde_with",
 ]
 
 [[package]]
@@ -329,15 +312,15 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.19.0"
+version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
 name = "bytes"
-version = "1.10.1"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cc"
@@ -368,28 +351,15 @@ dependencies = [
 
 [[package]]
 name = "cfg-if"
-version = "1.0.1"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
-
-[[package]]
-name = "chrono"
-version = "0.4.41"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c469d952047f47f91b68d1cba3f10d63c11d73e4636f24f08daf0278abf01c4d"
-dependencies = [
- "android-tzdata",
- "iana-time-zone",
- "num-traits",
- "serde",
- "windows-link 0.1.3",
-]
 
 [[package]]
 name = "clang-sys"
@@ -464,9 +434,9 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.17"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -479,29 +449,18 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crypto-common"
-version = "0.1.6"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
 dependencies = [
- "generic-array",
- "typenum",
-]
-
-[[package]]
-name = "deranged"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c9e6a11ca8224451684bc0d7d5a7adbf8f2fd6887261a1cfc3c0432f9d4068e"
-dependencies = [
- "powerfmt",
- "serde",
+ "hybrid-array",
 ]
 
 [[package]]
 name = "digest"
-version = "0.10.7"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
  "block-buffer",
  "crypto-common",
@@ -546,12 +505,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
-name = "dyn-clone"
-version = "1.0.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
-
-[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -559,9 +512,9 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "endi"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3d8a32ae18130a3c84dd492d4215c3d913c3b07c6b63c2eb3eb7ff1101ab7bf"
+checksum = "66b7e2430c6dff6a955451e2cfc438f09cea1965a9d6f87f7e3b90decc014099"
 
 [[package]]
 name = "enumflags2"
@@ -623,9 +576,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.3.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "filetime"
@@ -659,9 +612,9 @@ checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "form_urlencoded"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
@@ -689,9 +642,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -699,9 +652,9 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
 
 [[package]]
 name = "futures-executor"
@@ -716,9 +669,9 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
 
 [[package]]
 name = "futures-lite"
@@ -735,9 +688,9 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -746,21 +699,21 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
 
 [[package]]
 name = "futures-task"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
 
 [[package]]
 name = "futures-util"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -770,18 +723,7 @@ dependencies = [
  "futures-task",
  "memchr",
  "pin-project-lite",
- "pin-utils",
  "slab",
-]
-
-[[package]]
-name = "generic-array"
-version = "0.14.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bb6743198531e02858aeaea5398fcc883e71851fcbcb5a2f773e2fb6cb1edf2"
-dependencies = [
- "typenum",
- "version_check",
 ]
 
 [[package]]
@@ -806,20 +748,20 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
  "wasip2",
  "wasm-bindgen",
 ]
 
 [[package]]
 name = "getrandom"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "139ef39800118c7683f2fd3c98c1b23c09ae076556b435f8e9064ae108aaeeec"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 6.0.0",
  "wasip2",
  "wasip3",
 ]
@@ -832,9 +774,9 @@ checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "h2"
-version = "0.4.12"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3c0b69cfcb4e1b9f1bf2f53f95f766e4661169728ec61cd3fe5a0166f2d1386"
+checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -842,18 +784,12 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http",
- "indexmap 2.11.4",
+ "indexmap",
  "slab",
  "tokio",
  "tokio-util",
  "tracing",
 ]
-
-[[package]]
-name = "hashbrown"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
@@ -863,6 +799,12 @@ checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
  "foldhash",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
 
 [[package]]
 name = "heck"
@@ -895,7 +837,7 @@ dependencies = [
  "axum",
  "dirs",
  "fastrand",
- "getrandom 0.4.1",
+ "getrandom 0.4.2",
  "libc",
  "mahler",
  "mockito",
@@ -920,12 +862,11 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "http"
-version = "1.3.1"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4a85d31aea989eead29a3aaf9e1115a180df8282431156e533de47660892565"
+checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
 dependencies = [
  "bytes",
- "fnv",
  "itoa",
 ]
 
@@ -965,14 +906,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
-name = "hyper"
-version = "1.6.0"
+name = "hybrid-array"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc2b571658e38e0c01b1fdca3bbbe93c00d3d71693ff2770043f8c29bc7d6f80"
+checksum = "08d46837a0ed51fe95bd3b05de33cd64a1ee88fc797477ca48446872504507c5"
 dependencies = [
+ "typenum",
+]
+
+[[package]]
+name = "hyper"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
+dependencies = [
+ "atomic-waker",
  "bytes",
  "futures-channel",
- "futures-util",
+ "futures-core",
  "h2",
  "http",
  "http-body",
@@ -980,6 +931,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
+ "pin-utils",
  "smallvec",
  "tokio",
  "want",
@@ -1018,14 +970,13 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.15"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f66d5bd4c6f02bf0542fad85d626775bab9258cf795a4256dcaf3161114d1df"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
  "base64",
  "bytes",
  "futures-channel",
- "futures-core",
  "futures-util",
  "http",
  "http-body",
@@ -1034,7 +985,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2",
  "tokio",
  "tower-service",
  "tracing",
@@ -1053,30 +1004,6 @@ dependencies = [
  "pin-project-lite",
  "tokio",
  "tower-service",
-]
-
-[[package]]
-name = "iana-time-zone"
-version = "0.1.63"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0c919e5debc312ad217002b8048a17b7d83f80703865bbfcfebb0458b0b27d8"
-dependencies = [
- "android_system_properties",
- "core-foundation-sys",
- "iana-time-zone-haiku",
- "js-sys",
- "log",
- "wasm-bindgen",
- "windows-core",
-]
-
-[[package]]
-name = "iana-time-zone-haiku"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
-dependencies = [
- "cc",
 ]
 
 [[package]]
@@ -1194,32 +1121,21 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.9.3"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
-dependencies = [
- "autocfg",
- "hashbrown 0.12.3",
- "serde",
-]
-
-[[package]]
-name = "indexmap"
-version = "2.11.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b0f83760fb341a774ed326568e19f5a863af4a952def8c39f9ab92fd95b88e5"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.5",
+ "hashbrown 0.17.0",
  "serde",
  "serde_core",
 ]
 
 [[package]]
 name = "ipnet"
-version = "2.11.0"
+version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
 name = "iri-string"
@@ -1242,9 +1158,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.15"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jni"
@@ -1324,9 +1240,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.174"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libloading"
@@ -1335,7 +1251,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
 dependencies = [
  "cfg-if",
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -1351,9 +1267,9 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.11.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
@@ -1363,9 +1279,9 @@ checksum = "241eaef5fd12c88705a01fc1066c48c4b36e0dd4377dcdc7ec3942cea7a69956"
 
 [[package]]
 name = "log"
-version = "0.4.27"
+version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "lru-slab"
@@ -1436,9 +1352,9 @@ checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "memchr"
-version = "2.7.5"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
+checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "memoffset"
@@ -1463,13 +1379,13 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "mio"
-version = "1.0.4"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78bed444cc8a2160f01cbcf811ef18cac863ad68ae8ca62092e8db51d51c761c"
+checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
  "wasi",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1496,19 +1412,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "nix"
-version = "0.30.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
-dependencies = [
- "bitflags",
- "cfg-if",
- "cfg_aliases",
- "libc",
- "memoffset",
-]
-
-[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1528,25 +1431,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-conv"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
-
-[[package]]
-name = "num-traits"
-version = "0.2.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
-dependencies = [
- "autocfg",
-]
-
-[[package]]
 name = "once_cell"
-version = "1.21.3"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "openssl-probe"
@@ -1578,15 +1466,15 @@ checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "percent-encoding"
-version = "2.3.1"
+version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pin-utils"
@@ -1604,12 +1492,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "powerfmt"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
-
-[[package]]
 name = "ppv-lite86"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1620,9 +1502,9 @@ dependencies = [
 
 [[package]]
 name = "prettyplease"
-version = "0.2.36"
+version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff24dfcda44452b9816fff4cd4227e1bb73ff5a2f1bc1105aa92fb8565ce44d2"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
  "syn",
@@ -1630,18 +1512,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-crate"
-version = "3.4.0"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "219cb19e96be00ab2e37d6e299658a0cfa83e52429179969b0f0121b4ac46983"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
  "toml_edit",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.95"
+version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
@@ -1665,7 +1547,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.6.0",
+ "socket2",
  "thiserror 2.0.16",
  "tokio",
  "tracing",
@@ -1703,16 +1585,16 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.0",
+ "socket2",
  "tracing",
  "windows-sys 0.60.2",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.40"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
@@ -1722,6 +1604,12 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
@@ -1773,26 +1661,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ref-cast"
-version = "1.0.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a0ae411dbe946a674d89546582cea4ba2bb8defac896622d6496f14c23ba5cf"
-dependencies = [
- "ref-cast-impl",
-]
-
-[[package]]
-name = "ref-cast-impl"
-version = "1.0.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1165225c21bff1f3bbce98f5a1f889949bc902d3575308cc7b0de30b4f6d27c7"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "regex"
 version = "1.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1806,9 +1674,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5276caf25ac86c8d810222b3dbb938e512c55c6831a10f3e6ed1c93b84041f1c"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1817,9 +1685,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.8"
+version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "reqwest"
@@ -1883,9 +1751,9 @@ checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
 name = "rustix"
-version = "1.1.2"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
  "bitflags",
  "errno",
@@ -1971,15 +1839,15 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.21"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a0d197bd2c9dc6e53b84da9556a69ba4cdfab8619eb41a8bd1cc2027a0f6b1d"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "ryu"
-version = "1.0.20"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "same-file"
@@ -1997,30 +1865,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "891d81b926048e76efe18581bf793546b4c0eaf8448d72be8de2bbee5fd166e1"
 dependencies = [
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "schemars"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cd191f9397d57d581cddd31014772520aa448f65ef991055d7f61582c65165f"
-dependencies = [
- "dyn-clone",
- "ref-cast",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "schemars"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82d20c4491bc164fa2f6c5d44565947a52ad80b9505d8e36f8d54c27c739fcd0"
-dependencies = [
- "dyn-clone",
- "ref-cast",
- "serde",
- "serde_json",
 ]
 
 [[package]]
@@ -2048,9 +1892,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.27"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -2130,29 +1974,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_with"
-version = "3.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2c45cd61fefa9db6f254525d46e392b852e0e61d9a1fd36e5bd183450a556d5"
-dependencies = [
- "base64",
- "chrono",
- "hex",
- "indexmap 1.9.3",
- "indexmap 2.11.4",
- "schemars 0.9.0",
- "schemars 1.0.4",
- "serde",
- "serde_derive",
- "serde_json",
- "time",
-]
-
-[[package]]
 name = "sha2"
-version = "0.10.9"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -2176,10 +2001,11 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.4.6"
+version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2a4719bff48cee6b39d12c020eeb490953ad2443b7055bd0b21fca26bd8c28b"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
 dependencies = [
+ "errno",
  "libc",
 ]
 
@@ -2191,9 +2017,9 @@ checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 
 [[package]]
 name = "slab"
-version = "0.4.10"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04dc19736151f35336d325007ac991178d504a119863a2fcb3758cdb5e52c50d"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
@@ -2203,22 +2029,12 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "socket2"
-version = "0.5.10"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
+checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "socket2"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "233504af464074f9d066d7b5416c5f9b894a5862a6506e306f7b816cdd6f1807"
-dependencies = [
- "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2228,12 +2044,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
-name = "static_assertions"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
-
-[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2241,9 +2051,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "2.0.104"
+version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17b6f705963418cdb9927482fa304bc562ece2fdd4f616084c50b7023b435a40"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2283,12 +2093,12 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.23.0"
+version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d31c77bdf42a745371d260a26ca7163f1e0924b64afa0b688e61b5a9fa02f16"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -2344,37 +2154,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "time"
-version = "0.3.41"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a7619e19bc266e0f9c5e6686659d394bc57973859340060a69221e57dbc0c40"
-dependencies = [
- "deranged",
- "itoa",
- "num-conv",
- "powerfmt",
- "serde",
- "time-core",
- "time-macros",
-]
-
-[[package]]
-name = "time-core"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9e9a38711f559d9e3ce1cdb06dd7c5b8ea546bc90052da6d06bb76da74bb07c"
-
-[[package]]
-name = "time-macros"
-version = "0.2.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3526739392ec93fd8b359c8e98514cb3e8e021beb4e5f597b00a0221f8ed8a49"
-dependencies = [
- "num-conv",
- "time-core",
-]
-
-[[package]]
 name = "tinystr"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2401,16 +2180,16 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.49.0"
+version = "1.52.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72a2903cd7736441aac9df9d7688bd0ce48edccaadf181c3b90be801e81d3d86"
+checksum = "110a78583f19d5cdb2c5ccf321d1290344e71313c6c37d43520d386027d18386"
 dependencies = [
  "bytes",
  "libc",
  "mio",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.6.0",
+ "socket2",
  "tokio-macros",
  "tracing",
  "windows-sys 0.61.2",
@@ -2418,9 +2197,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.0"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2451,9 +2230,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.16"
+version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14307c986784f72ef81c89db7d9e28d6ac26d16213b109ea501696195e6e3ce5"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
 dependencies = [
  "bytes",
  "futures-core",
@@ -2464,20 +2243,20 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.7.3"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2cdb639ebbc97961c51720f858597f7f24c4fc295327923af55b74c3c724533"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
 dependencies = [
  "serde_core",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.23.7"
+version = "0.25.11+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6485ef6d0d9b5d0ec17244ff7eb05310113c3f316f2d14200d4de56b3cb98f8d"
+checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
 dependencies = [
- "indexmap 2.11.4",
+ "indexmap",
  "toml_datetime",
  "toml_parser",
  "winnow",
@@ -2485,18 +2264,18 @@ dependencies = [
 
 [[package]]
 name = "toml_parser"
-version = "1.0.4"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0cbe268d35bdb4bb5a56a2de88d0ad0eb70af5384a99d648cd4b3d04039800e"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
  "winnow",
 ]
 
 [[package]]
 name = "tower"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
 dependencies = [
  "futures-core",
  "futures-util",
@@ -2587,9 +2366,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.20"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2054a14f5307d601f88daf0553e1cbf472acc4f2c51afab632431cdcd72124d5"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
 dependencies = [
  "matchers",
  "nu-ansi-term",
@@ -2611,9 +2390,9 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "typenum"
-version = "1.19.0"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
 name = "uds_windows"
@@ -2628,9 +2407,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.18"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "unicode-xid"
@@ -2663,12 +2442,13 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "uuid"
-version = "1.18.1"
+version = "1.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f87b8aa10b915a06587d0dec516c282ff295b475d94abf425d62b57710070a2"
+checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
 dependencies = [
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "js-sys",
+ "serde_core",
  "wasm-bindgen",
 ]
 
@@ -2677,12 +2457,6 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
-
-[[package]]
-name = "version_check"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "walkdir"
@@ -2711,11 +2485,11 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.1+wasi-0.2.4"
+version = "1.0.2+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
+checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
 dependencies = [
- "wit-bindgen 0.46.0",
+ "wit-bindgen",
 ]
 
 [[package]]
@@ -2724,7 +2498,7 @@ version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
- "wit-bindgen 0.51.0",
+ "wit-bindgen",
 ]
 
 [[package]]
@@ -2815,7 +2589,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
 dependencies = [
  "anyhow",
- "indexmap 2.11.4",
+ "indexmap",
  "wasm-encoder",
  "wasmparser",
 ]
@@ -2841,7 +2615,7 @@ checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
  "bitflags",
  "hashbrown 0.15.5",
- "indexmap 2.11.4",
+ "indexmap",
  "semver",
 ]
 
@@ -2906,69 +2680,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
-name = "windows-core"
-version = "0.61.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
-dependencies = [
- "windows-implement",
- "windows-interface",
- "windows-link 0.1.3",
- "windows-result",
- "windows-strings",
-]
-
-[[package]]
-name = "windows-implement"
-version = "0.60.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "windows-interface"
-version = "0.59.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "windows-link"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
-
-[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
-
-[[package]]
-name = "windows-result"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
-dependencies = [
- "windows-link 0.1.3",
-]
-
-[[package]]
-name = "windows-strings"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
-dependencies = [
- "windows-link 0.1.3",
-]
 
 [[package]]
 name = "windows-sys"
@@ -2990,15 +2705,6 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.59.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
-dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
@@ -3012,7 +2718,7 @@ version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -3052,7 +2758,7 @@ version = "0.53.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
 dependencies = [
- "windows-link 0.2.1",
+ "windows-link",
  "windows_aarch64_gnullvm 0.53.1",
  "windows_aarch64_msvc 0.53.1",
  "windows_i686_gnu 0.53.1",
@@ -3203,18 +2909,12 @@ checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
-version = "0.7.13"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21a0236b59786fed61e2a80582dd500fe61f18b5dca67a4a067d0bc9039339cf"
+checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
 dependencies = [
  "memchr",
 ]
-
-[[package]]
-name = "wit-bindgen"
-version = "0.46.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
 
 [[package]]
 name = "wit-bindgen"
@@ -3244,7 +2944,7 @@ checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
 dependencies = [
  "anyhow",
  "heck",
- "indexmap 2.11.4",
+ "indexmap",
  "prettyplease",
  "syn",
  "wasm-metadata",
@@ -3275,7 +2975,7 @@ checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
  "bitflags",
- "indexmap 2.11.4",
+ "indexmap",
  "log",
  "serde",
  "serde_derive",
@@ -3294,7 +2994,7 @@ checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
 dependencies = [
  "anyhow",
  "id-arena",
- "indexmap 2.11.4",
+ "indexmap",
  "log",
  "semver",
  "serde",
@@ -3346,9 +3046,9 @@ dependencies = [
 
 [[package]]
 name = "zbus"
-version = "5.11.0"
+version = "5.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d07e46d035fb8e375b2ce63ba4e4ff90a7f73cf2ffb0138b29e1158d2eaadf7"
+checksum = "c3bcbf15c8708d7fc1be0c993622e0a5cbd5e8b52bfa40afa4c3e0cd8d724ac1"
 dependencies = [
  "async-broadcast",
  "async-recursion",
@@ -3358,14 +3058,16 @@ dependencies = [
  "futures-core",
  "futures-lite",
  "hex",
- "nix",
+ "libc",
  "ordered-stream",
+ "rustix",
  "serde",
  "serde_repr",
  "tokio",
  "tracing",
  "uds_windows",
- "windows-sys 0.60.2",
+ "uuid",
+ "windows-sys 0.61.2",
  "winnow",
  "zbus_macros",
  "zbus_names",
@@ -3374,9 +3076,9 @@ dependencies = [
 
 [[package]]
 name = "zbus_macros"
-version = "5.11.0"
+version = "5.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57e797a9c847ed3ccc5b6254e8bcce056494b375b511b3d6edcec0aeb4defaca"
+checksum = "51fa5406ad9175a8c825a931f8cf347116b531b3634fcb0b627c290f1f2516ff"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -3389,12 +3091,11 @@ dependencies = [
 
 [[package]]
 name = "zbus_names"
-version = "4.2.0"
+version = "4.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7be68e64bf6ce8db94f63e72f0c7eb9a60d733f7e0499e628dfab0f84d6bcb97"
+checksum = "7074f3e50b894eac91750142016d30d0a89be8e67dbfd9704fb875825760e52d"
 dependencies = [
  "serde",
- "static_assertions",
  "winnow",
  "zvariant",
 ]
@@ -3481,15 +3182,15 @@ dependencies = [
 
 [[package]]
 name = "zmij"
-version = "1.0.15"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94f63c051f4fe3c1509da62131a678643c5b6fbdc9273b2b79d4378ebda003d2"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
 
 [[package]]
 name = "zvariant"
-version = "5.7.0"
+version = "5.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "999dd3be73c52b1fccd109a4a81e4fcd20fab1d3599c8121b38d04e1419498db"
+checksum = "1c1567a6ec68df868cbbfde844cfc6d81649fe5109a62b116b19fabd53e618ee"
 dependencies = [
  "endi",
  "enumflags2",
@@ -3501,9 +3202,9 @@ dependencies = [
 
 [[package]]
 name = "zvariant_derive"
-version = "5.7.0"
+version = "5.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6643fd0b26a46d226bd90d3f07c1b5321fe9bb7f04673cb37ac6d6883885b68e"
+checksum = "c7d5b780599bbde114e39d9a0799577fad1ced5105d38515745f7b3099d8ceda"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -3514,9 +3215,9 @@ dependencies = [
 
 [[package]]
 name = "zvariant_utils"
-version = "3.2.1"
+version = "3.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6949d142f89f6916deca2232cf26a8afacf2b9fdc35ce766105e104478be599"
+checksum = "6d464f5733ffa07a3164d656f18533caace9d0638596721355d73256a410d691"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/helios-integration-tests/Cargo.toml
+++ b/helios-integration-tests/Cargo.toml
@@ -21,14 +21,14 @@ edition.workspace = true
 [workspace.dependencies]
 addr = { version = "0.15.6", default-features = false }
 futures-util = "0.3"
-axum = { version = "0.8.6", default-features = false, features = [
+axum = { version = "0.8.9", default-features = false, features = [
   "tokio",
   "http1",
   "json",
   "query",
 ] }
 dirs = "6.0.0"
-fastrand = "2.3.0"
+fastrand = "2.4.1"
 getrandom = { version = "0.4", default-features = false, features = ["std"] }
 mahler = "0.25"
 regex = "1.12"
@@ -40,10 +40,10 @@ reqwest = { version = "0.13", default-features = false, features = [
 ] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-sha2 = { version = "0.10.9", default-features = false }
+sha2 = { version = "0.11", default-features = false }
 tar = "0.4"
 thiserror = "2"
-tokio = { version = "1.47.1", default-features = false, features = [
+tokio = { version = "1.52.2", default-features = false, features = [
   "rt-multi-thread",
   "macros",
   "time",
@@ -53,14 +53,14 @@ tokio = { version = "1.47.1", default-features = false, features = [
 tokio-stream = { version = "0.1.18", default-features = false, features = [
   "sync",
 ] }
-tracing = "0.1.41"
-uuid = { version = "1.18", features = ["v4"] }
-zbus = { version = "5.11", default-features = false, features = ["tokio"] }
+tracing = "0.1.44"
+uuid = { version = "1.23", features = ["v4"] }
+zbus = { version = "5.15", default-features = false, features = ["tokio"] }
 
 # workspace dev dependencies
-bollard = "0.20"
+bollard = "0.21"
 mockito = { version = "1.7", default-features = false }
-tracing-subscriber = { version = "0.3.20", features = [
+tracing-subscriber = { version = "0.3.23", features = [
   "env-filter",
   "fmt",
   "registry",

--- a/helios-integration-tests/src/api_tests.rs
+++ b/helios-integration-tests/src/api_tests.rs
@@ -478,24 +478,24 @@ async fn test_set_app_target_install_images() {
     // service-one received the short-form volume mount `my-vol:/backup:ro`.
     // Docker reports the mount source as the namespaced volume name.
     let svc_one_backup = container_mount(&svc_one_container, "/backup");
-    assert_eq!(svc_one_backup.typ.unwrap().as_ref(), "volume");
+    assert_eq!(svc_one_backup.typ.as_ref().unwrap(), "volume");
     assert_eq!(svc_one_backup.name.as_deref(), Some(my_vol_id.as_str()));
     assert_eq!(svc_one_backup.rw, Some(false));
 
     // service-two declares a volume mount, a bind mount, and a tmpfs mount
     // via the long-form syntax.
     let svc_two_data = container_mount(&svc_two_container, "/data");
-    assert_eq!(svc_two_data.typ.unwrap().as_ref(), "volume");
+    assert_eq!(svc_two_data.typ.as_ref().unwrap(), "volume");
     assert_eq!(svc_two_data.name.as_deref(), Some(my_vol_id.as_str()));
     assert_eq!(svc_two_data.rw, Some(false));
 
     let svc_two_machine_id = container_mount(&svc_two_container, "/host/proc");
-    assert_eq!(svc_two_machine_id.typ.unwrap().as_ref(), "bind");
+    assert_eq!(svc_two_machine_id.typ.as_ref().unwrap(), "bind");
     assert_eq!(svc_two_machine_id.source.as_deref(), Some("/proc"));
     assert_eq!(svc_two_machine_id.rw, Some(true));
 
     let svc_two_tmp = container_mount(&svc_two_container, "/run/tmp");
-    assert_eq!(svc_two_tmp.typ.unwrap().as_ref(), "tmpfs");
+    assert_eq!(svc_two_tmp.typ.as_ref().unwrap(), "tmpfs");
 
     // The host-level tmpfs options that were sent to the engine should round-trip
     // through the `HostConfig.Mounts` spec.

--- a/helios-oci/src/container.rs
+++ b/helios-oci/src/container.rs
@@ -7,7 +7,7 @@ use bollard::{
     },
     models::{
         ContainerCreateBody, MountBindOptions, MountBindOptionsPropagationEnum, MountTmpfsOptions,
-        MountTypeEnum, MountVolumeOptions,
+        MountType, MountVolumeOptions,
     },
     query_parameters::{
         CreateContainerOptions, DownloadFromContainerOptions, ListContainersOptions,
@@ -391,6 +391,7 @@ impl From<ContainerStateStatusEnum> for ContainerStatus {
             RUNNING => ContainerStatus::Running,
             PAUSED => ContainerStatus::Stopped,
             RESTARTING => ContainerStatus::Running,
+            STOPPING => ContainerStatus::Stopped,
             REMOVING => ContainerStatus::Stopped,
             EXITED => ContainerStatus::Stopped,
             DEAD => ContainerStatus::Dead,
@@ -645,7 +646,7 @@ impl From<Mount> for bollard::models::Mount {
                     None
                 };
                 bollard::models::Mount {
-                    typ: Some(MountTypeEnum::VOLUME),
+                    typ: Some(MountType::VOLUME),
                     target: Some(target),
                     source: Some(source),
                     read_only: Some(read_only),
@@ -664,7 +665,7 @@ impl From<Mount> for bollard::models::Mount {
                     ..Default::default()
                 });
                 bollard::models::Mount {
-                    typ: Some(MountTypeEnum::BIND),
+                    typ: Some(MountType::BIND),
                     target: Some(target),
                     source: Some(source),
                     read_only: Some(read_only),
@@ -683,7 +684,7 @@ impl From<Mount> for bollard::models::Mount {
                     None
                 };
                 bollard::models::Mount {
-                    typ: Some(MountTypeEnum::TMPFS),
+                    typ: Some(MountType::TMPFS),
                     target: Some(target),
                     tmpfs_options,
                     ..Default::default()
@@ -708,7 +709,7 @@ impl TryFrom<bollard::models::Mount> for Mount {
         let target = value.target.ok_or("mount target is required")?;
         let read_only = value.read_only.unwrap_or_default();
         match value.typ {
-            Some(MountTypeEnum::VOLUME) => {
+            Some(MountType::VOLUME) => {
                 let source = value.source.unwrap_or_default();
                 let (nocopy, subpath) = value
                     .volume_options
@@ -722,7 +723,7 @@ impl TryFrom<bollard::models::Mount> for Mount {
                     subpath,
                 })
             }
-            Some(MountTypeEnum::BIND) => {
+            Some(MountType::BIND) => {
                 let source = value.source.unwrap_or_default();
                 let propagation = value
                     .bind_options
@@ -735,7 +736,7 @@ impl TryFrom<bollard::models::Mount> for Mount {
                     propagation,
                 })
             }
-            Some(MountTypeEnum::TMPFS) => {
+            Some(MountType::TMPFS) => {
                 let (size, mode) = value
                     .tmpfs_options
                     .map(|o| (o.size_bytes, o.mode.map(|m| m as u32)))
@@ -924,7 +925,7 @@ mod tests {
 
     fn vol_mount(target: &str, source: &str) -> EngineMount {
         EngineMount {
-            typ: Some(MountTypeEnum::VOLUME),
+            typ: Some(MountType::VOLUME),
             target: Some(target.to_string()),
             source: Some(source.to_string()),
             read_only: Some(false),
@@ -968,7 +969,7 @@ mod tests {
         // An `image` mount on an existing container must not cause the inspect
         // conversion to fail — it round-trips as `Mount::Other`.
         let image_mount = EngineMount {
-            typ: Some(MountTypeEnum::IMAGE),
+            typ: Some(MountType::IMAGE),
             target: Some("/data".to_string()),
             source: Some("some/image".to_string()),
             ..Default::default()
@@ -987,7 +988,7 @@ mod tests {
     #[test]
     fn inspect_fails_on_missing_mount_target() {
         let no_target = EngineMount {
-            typ: Some(MountTypeEnum::VOLUME),
+            typ: Some(MountType::VOLUME),
             target: None,
             source: Some("vol".to_string()),
             ..Default::default()

--- a/helios-state/src/tasks/app.rs
+++ b/helios-state/src/tasks/app.rs
@@ -1003,6 +1003,10 @@ fn uninstall_service_when_requirements_are_met(
     // config and image, then do a migration
     if let Some((t_rel_uuid, tgt_svc)) =
         find_future_service(&t_device, &app_uuid, &rel_uuid, &svc_name)
+        && device
+            .apps
+            .get(&app_uuid)
+            .is_some_and(|app| app.releases.contains_key(t_rel_uuid))
         && svc.image.is_same_artifact(&tgt_svc.image)
         && svc.started == tgt_svc.started
         && svc.config == tgt_svc.config

--- a/helios-state/src/tasks/app.rs
+++ b/helios-state/src/tasks/app.rs
@@ -12,7 +12,7 @@ use crate::models::{
 use crate::store::{self, DocumentStore};
 
 use crate::oci::{Client as Docker, Error as OciError, Mount, WithContext};
-use crate::tasks::utils::find_installed_network;
+use crate::tasks::utils::{find_installed_network, find_installed_volume};
 
 use super::image::create_image;
 use super::utils::{
@@ -358,6 +358,22 @@ fn uninstall_network(net: View<Network>, docker: Res<Docker>) -> IO<Option<Netwo
     })
 }
 
+fn create_volume_when_requirements_are_met(
+    System(device): System<Device>,
+    Target(tgt): Target<Volume>,
+    Args((app_uuid, rel_uuid, vol_name)): Args<(Uuid, Uuid, String)>,
+) -> Option<Task> {
+    // Do not create a new volume if there is an installed volume from a different release
+    // as that volume needs to be removed first
+    if let Some(cur_vol) = find_installed_volume(&device, &app_uuid, &rel_uuid, &vol_name)
+        && tgt.config != cur_vol.config
+    {
+        return None;
+    }
+
+    Some(create_volume.into_task())
+}
+
 /// Create or migrate a volume
 ///
 /// If the volume already exists in Docker with the same config, migrate it
@@ -401,60 +417,12 @@ fn create_volume(
 
 /// Reconfigure a volume by uninstalling it when the config has changed
 ///
-/// Services referencing the volume that already have a container are torn down
-/// first; the planner will then uninstall and re-create the volume, and
-/// re-install the services on the next cycle.
-fn reconfigure_volume(
-    vol: View<Volume>,
-    System(device): System<Device>,
-    Target(tgt): Target<Volume>,
-    Args((app_uuid, _, vol_name)): Args<(Uuid, Uuid, String)>,
-) -> Vec<Task> {
+/// After uninstall, the planner will re-create the volume with the new config.
+fn reconfigure_volume(vol: View<Volume>, Target(tgt): Target<Volume>) -> Option<Task> {
     if vol.config != tgt.config {
-        let mut tasks = Vec::new();
-        let services_depending_on_volume = device
-            .apps
-            .get(&app_uuid)
-            .map(|app| {
-                app.releases
-                    .iter()
-                    .flat_map(|(rel_uuid, rel)| {
-                        rel.services
-                            .iter()
-                            .filter(|(_, svc)| {
-                                svc.oci.is_some()
-                                    && svc.config.volumes.iter().any(|m| {
-                                        matches!(m, Mount::Volume { source, .. }
-                                            if source == &vol_name)
-                                    })
-                            })
-                            .map(move |(svc_name, _)| (rel_uuid, svc_name))
-                    })
-                    .collect::<Vec<(&Uuid, &String)>>()
-            })
-            .unwrap_or_default();
-
-        for (rel_uuid, svc_name) in services_depending_on_volume {
-            tasks.push(
-                stop_service_when_requirements_are_met
-                    .with_arg("commit", rel_uuid.as_str())
-                    .with_arg("service_name", svc_name),
-            );
-            tasks.push(
-                remove_service_container
-                    .with_arg("commit", rel_uuid.as_str())
-                    .with_arg("service_name", svc_name),
-            );
-        }
-
-        if tasks.is_empty() {
-            tasks.push(uninstall_volume.into_task());
-        }
-
-        tasks
-    } else {
-        Vec::new()
+        return Some(remove_volume_when_requirements_are_met.into_task());
     }
+    None
 }
 
 /// Uninstall a volume from Docker and the state tree
@@ -557,7 +525,8 @@ fn remove_volume_when_requirements_are_met(
     System(device): System<Device>,
     SystemTarget(t_device): SystemTarget<Device>,
     Args((app_uuid, rel_uuid, vol_name)): Args<(Uuid, Uuid, String)>,
-) -> Option<Task> {
+) -> Vec<Task> {
+    let mut tasks = Vec::new();
     if let Some((t_rel_uuid, future_vol)) =
         find_future_volume(&t_device, &app_uuid, &rel_uuid, &vol_name)
         && vol.config == future_vol.config
@@ -570,31 +539,55 @@ fn remove_volume_when_requirements_are_met(
             .and_then(|app| app.releases.get(t_rel_uuid))
             .is_some_and(|rel| rel.volumes.contains_key(&vol_name));
 
-        if !new_vol_exists {
-            return None;
+        // State-only removal, Docker volume preserved for new release to adopt
+        if new_vol_exists {
+            tasks.push(remove_volume.into_task());
+        }
+    } else {
+        let services_depending_on_volume = device
+            .apps
+            .get(&app_uuid)
+            .map(|app| {
+                app.releases
+                    .iter()
+                    .flat_map(|(rel_uuid, rel)| {
+                        rel.services
+                            .iter()
+                            // find any services referencing the volume that have a container
+                            .filter(|(_, svc)| {
+                                svc.oci.is_some()
+                                    && svc.config.volumes.iter().any(|m| {
+                                        matches!(m, Mount::Volume { source, .. }
+                                            if source == &vol_name)
+                                    })
+                            })
+                            .map(move |(svc_name, _)| (rel_uuid, svc_name))
+                    })
+                    .collect::<Vec<(&Uuid, &String)>>()
+            })
+            .unwrap_or_default();
+
+        // uninstall any services depending on the volume first
+        for (rel_uuid, svc_name) in services_depending_on_volume {
+            tasks.push(
+                stop_service_when_requirements_are_met
+                    .with_arg("commit", rel_uuid.as_str())
+                    .with_arg("service_name", svc_name),
+            );
+            tasks.push(
+                uninstall_service
+                    .with_arg("commit", rel_uuid.as_str())
+                    .with_arg("service_name", svc_name),
+            );
         }
 
-        // State-only removal, Docker volume preserved for new release to adopt
-        Some(remove_volume.into_task())
-    } else {
-        let services_depend_on_volume = device.apps.get(&app_uuid).is_some_and(|app| {
-            app.releases.values().any(|rel| {
-                rel.services.values().any(|svc| {
-                    svc.config
-                        .volumes
-                        .iter()
-                        .any(|m| matches!(m, Mount::Volume { source, .. } if source == &vol_name))
-                })
-            })
-        });
-
-        // Cannot uninstall a volume that has dependent services on any installed release
-        if !services_depend_on_volume {
-            Some(uninstall_volume.into_task())
-        } else {
-            None
+        // once services have been uninstalled, then remove the volume
+        if tasks.is_empty() {
+            tasks.push(uninstall_volume.into_task());
         }
     }
+
+    tasks
 }
 
 /// Remove volume from the current release state
@@ -1205,7 +1198,8 @@ pub fn with_userapp_tasks<O>(worker: Worker<O, Uninitialized>) -> Worker<O, Unin
         .jobs(
             "/apps/{app_uuid}/releases/{commit}/volumes/{volume_name}",
             [
-                job::create(create_volume).with_description(
+                job::create(create_volume_when_requirements_are_met),
+                job::none(create_volume).with_description(
                     |Args((app_uuid, _, volume_name)): Args<(Uuid, Uuid, String)>| {
                         format!("setup volume '{volume_name}' for app '{app_uuid}'")
                     },

--- a/helios-state/src/tasks/app.rs
+++ b/helios-state/src/tasks/app.rs
@@ -12,6 +12,7 @@ use crate::models::{
 use crate::store::{self, DocumentStore};
 
 use crate::oci::{Client as Docker, Error as OciError, Mount, WithContext};
+use crate::tasks::utils::find_installed_network;
 
 use super::image::create_image;
 use super::utils::{
@@ -275,6 +276,22 @@ fn remove_release(mut release: View<Option<Release>>) -> View<Option<Release>> {
     release
 }
 
+fn create_network_when_requirements_are_met(
+    System(device): System<Device>,
+    Target(tgt): Target<Network>,
+    Args((app_uuid, rel_uuid, net_name)): Args<(Uuid, Uuid, String)>,
+) -> Option<Task> {
+    // Do not create a new network if there is an installed network from a different release
+    // as that network needs to be removed first
+    if let Some(cur_net) = find_installed_network(&device, &app_uuid, &rel_uuid, &net_name)
+        && tgt.config != cur_net.config
+    {
+        return None;
+    }
+
+    Some(create_network.into_task())
+}
+
 /// Create or migrate a network
 ///
 /// If the network already exists in Docker with the same config, migrate it
@@ -320,55 +337,11 @@ fn create_network(
 /// Reconfigure a network by uninstalling it when the config has changed
 ///
 /// After uninstall, the planner will re-create the network with the new config.
-fn reconfigure_network(
-    net: View<Network>,
-    System(device): System<Device>,
-    Target(tgt): Target<Network>,
-    Args((app_uuid, _, net_name)): Args<(Uuid, Uuid, String)>,
-) -> Vec<Task> {
+fn reconfigure_network(net: View<Network>, Target(tgt): Target<Network>) -> Option<Task> {
     if net.config != tgt.config {
-        let mut tasks = Vec::new();
-        let services_depending_on_network = device
-            .apps
-            .get(&app_uuid)
-            .map(|app| {
-                app.releases
-                    .iter()
-                    .flat_map(|(rel_uuid, rel)| {
-                        rel.services
-                            .iter()
-                            // find any services referencing the network that have a container
-                            .filter(|(_, svc)| {
-                                svc.oci.is_some() && svc.config.networks.contains_key(&net_name)
-                            })
-                            .map(move |(svc_name, _)| (rel_uuid, svc_name))
-                    })
-                    .collect::<Vec<(&Uuid, &String)>>()
-            })
-            .unwrap_or_default();
-
-        // uninstall any services depending on the network first
-        for (rel_uuid, svc_name) in services_depending_on_network {
-            tasks.push(
-                stop_service_when_requirements_are_met
-                    .with_arg("commit", rel_uuid.as_str())
-                    .with_arg("service_name", svc_name),
-            );
-            tasks.push(
-                remove_service_container
-                    .with_arg("commit", rel_uuid.as_str())
-                    .with_arg("service_name", svc_name),
-            );
-        }
-
-        if tasks.is_empty() {
-            tasks.push(uninstall_network.into_task());
-        }
-
-        tasks
-    } else {
-        Vec::new()
+        return Some(remove_network_when_requirements_are_met.into_task());
     }
+    None
 }
 
 /// Uninstall a network from Docker and the state tree
@@ -508,7 +481,8 @@ fn remove_network_when_requirements_are_met(
     System(device): System<Device>,
     SystemTarget(t_device): SystemTarget<Device>,
     Args((app_uuid, rel_uuid, net_name)): Args<(Uuid, Uuid, String)>,
-) -> Option<Task> {
+) -> Vec<Task> {
+    let mut tasks = Vec::new();
     if let Some((t_rel_uuid, future_net)) =
         find_future_network(&t_device, &app_uuid, &rel_uuid, &net_name)
         && net.config == future_net.config
@@ -521,28 +495,51 @@ fn remove_network_when_requirements_are_met(
             .and_then(|app| app.releases.get(t_rel_uuid))
             .is_some_and(|rel| rel.networks.contains_key(&net_name));
 
-        if !new_net_exists {
-            return None;
+        // State-only removal, Docker network preserved for new release to adopt
+        if new_net_exists {
+            tasks.push(remove_network.into_task());
+        }
+    } else {
+        let services_depending_on_network = device
+            .apps
+            .get(&app_uuid)
+            .map(|app| {
+                app.releases
+                    .iter()
+                    .flat_map(|(rel_uuid, rel)| {
+                        rel.services
+                            .iter()
+                            // find any services referencing the network that have a container
+                            .filter(|(_, svc)| {
+                                svc.oci.is_some() && svc.config.networks.contains_key(&net_name)
+                            })
+                            .map(move |(svc_name, _)| (rel_uuid, svc_name))
+                    })
+                    .collect::<Vec<(&Uuid, &String)>>()
+            })
+            .unwrap_or_default();
+
+        // uninstall any services depending on the network first
+        for (rel_uuid, svc_name) in services_depending_on_network {
+            tasks.push(
+                stop_service_when_requirements_are_met
+                    .with_arg("commit", rel_uuid.as_str())
+                    .with_arg("service_name", svc_name),
+            );
+            tasks.push(
+                uninstall_service
+                    .with_arg("commit", rel_uuid.as_str())
+                    .with_arg("service_name", svc_name),
+            );
         }
 
-        // State-only removal, Docker network preserved for new release to adopt
-        Some(remove_network.into_task())
-    } else {
-        let services_depend_on_network = device.apps.get(&app_uuid).is_some_and(|app| {
-            app.releases.values().any(|rel| {
-                rel.services
-                    .values()
-                    .any(|svc| svc.config.networks.contains_key(&net_name))
-            })
-        });
-
-        // Cannot uninstall a network that has dependent services on any installed release
-        if !services_depend_on_network {
-            Some(uninstall_network.into_task())
-        } else {
-            None
+        // once services have been uninstalled, then remove the network
+        if tasks.is_empty() {
+            tasks.push(uninstall_network.into_task());
         }
     }
+
+    tasks
 }
 
 /// Remove network from the current release state
@@ -998,14 +995,14 @@ fn uninstall_service_when_requirements_are_met(
     let mut tasks = Vec::new();
 
     // wait until all target images have been downloaded
-    if t_device.apps.get(&app_uuid).is_some_and(|t_app| 
+    if t_device.apps.get(&app_uuid).is_some_and(|t_app| {
         t_app.releases.iter().any(|(t_rel_uuid, t_rel)| {
             t_rel_uuid != &rel_uuid
                 && t_rel.services.values().any(|t_svc| {
                     !matches!(&t_svc.image, ImageRef::Uri(t_img_uri) if device.images.contains_key(t_img_uri))
                 })
         })
-    ) {
+    }) {
         return tasks;
     }
 
@@ -1185,7 +1182,8 @@ pub fn with_userapp_tasks<O>(worker: Worker<O, Uninitialized>) -> Worker<O, Unin
         .jobs(
             "/apps/{app_uuid}/releases/{commit}/networks/{network_name}",
             [
-                job::create(create_network).with_description(
+                job::create(create_network_when_requirements_are_met),
+                job::none(create_network).with_description(
                     |Args((app_uuid, _, network_name)): Args<(Uuid, Uuid, String)>| {
                         format!("setup network '{network_name}' for app '{app_uuid}'")
                     },

--- a/helios-state/src/tasks/app.rs
+++ b/helios-state/src/tasks/app.rs
@@ -213,7 +213,11 @@ fn finish_release(
             release
                 .services
                 .get(svc_name)
-                .map(|svc| tgt_svc == &ServiceTarget::from(svc.clone()))
+                .map(|svc| {
+                    svc.started == tgt_svc.started
+                        && svc.image == tgt_svc.image
+                        && svc.config == tgt_svc.config
+                })
                 .unwrap_or_default()
         }),
         "all services should have the correct configuration"
@@ -737,8 +741,11 @@ fn install_service_when_requirements_are_met(
         && volumes_ready
         && let ImageRef::Uri(tgt_img) = &tgt.image
         && device.images.contains_key(tgt_img)
-        && find_installed_service(&device, &app_uuid, &rel_uuid, &svc_name)
-            .is_none_or(|svc| !svc.image.is_same_artifact(&tgt.image) || svc.config != tgt.config)
+        && find_installed_service(&device, &app_uuid, &rel_uuid, &svc_name).is_none_or(|svc| {
+            !svc.image.is_same_artifact(&tgt.image)
+                || svc.started != tgt.started
+                || svc.config != tgt.config
+        })
     {
         return Some(install_service.with_target(tgt));
     }
@@ -991,14 +998,14 @@ fn uninstall_service_when_requirements_are_met(
     let mut tasks = Vec::new();
 
     // wait until all target images have been downloaded
-    if t_device.apps.values().any(|t_app| {
+    if t_device.apps.get(&app_uuid).is_some_and(|t_app| 
         t_app.releases.iter().any(|(t_rel_uuid, t_rel)| {
             t_rel_uuid != &rel_uuid
                 && t_rel.services.values().any(|t_svc| {
                     !matches!(&t_svc.image, ImageRef::Uri(t_img_uri) if device.images.contains_key(t_img_uri))
                 })
         })
-    }) {
+    ) {
         return tasks;
     }
 
@@ -1007,6 +1014,7 @@ fn uninstall_service_when_requirements_are_met(
     if let Some((t_rel_uuid, tgt_svc)) =
         find_future_service(&t_device, &app_uuid, &rel_uuid, &svc_name)
         && svc.image.is_same_artifact(&tgt_svc.image)
+        && svc.started == tgt_svc.started
         && svc.config == tgt_svc.config
     {
         tasks.push(remove_service.into_task());

--- a/helios-state/src/tasks/utils.rs
+++ b/helios-state/src/tasks/utils.rs
@@ -1,5 +1,7 @@
 use crate::common_types::Uuid;
-use crate::models::{Device, DeviceTarget, NetworkTarget, Service, ServiceTarget, VolumeTarget};
+use crate::models::{
+    Device, DeviceTarget, Network, NetworkTarget, Service, ServiceTarget, VolumeTarget,
+};
 
 /// Find an installed service for a different commit
 pub fn find_installed_service<'a>(
@@ -34,6 +36,27 @@ pub fn find_future_network<'a>(
                     .iter()
                     .find(|(k, _)| k == &network_name)
                     .map(|(_, n)| (c, n))
+            })
+            .next()
+    })
+}
+
+/// Find a new network for a different commit
+pub fn find_installed_network<'a>(
+    device: &'a Device,
+    app_uuid: &'a Uuid,
+    commit: &'a Uuid,
+    network_name: &'a String,
+) -> Option<&'a Network> {
+    device.apps.get(app_uuid).and_then(|app| {
+        app.releases
+            .iter()
+            .filter(|(c, _)| c != &commit)
+            .flat_map(|(_, r)| {
+                r.networks
+                    .iter()
+                    .find(|(k, _)| k == &network_name)
+                    .map(|(_, n)| n)
             })
             .next()
     })

--- a/helios-state/src/tasks/utils.rs
+++ b/helios-state/src/tasks/utils.rs
@@ -1,6 +1,6 @@
 use crate::common_types::Uuid;
 use crate::models::{
-    Device, DeviceTarget, Network, NetworkTarget, Service, ServiceTarget, VolumeTarget,
+    Device, DeviceTarget, Network, NetworkTarget, Service, ServiceTarget, Volume, VolumeTarget,
 };
 
 /// Find an installed service for a different commit
@@ -78,6 +78,27 @@ pub fn find_future_volume<'a>(
                     .iter()
                     .find(|(k, _)| k == &volume_name)
                     .map(|(_, v)| (c, v))
+            })
+            .next()
+    })
+}
+
+/// Find an installed volume for a different commit
+pub fn find_installed_volume<'a>(
+    device: &'a Device,
+    app_uuid: &'a Uuid,
+    commit: &'a Uuid,
+    volume_name: &'a String,
+) -> Option<&'a Volume> {
+    device.apps.get(app_uuid).and_then(|app| {
+        app.releases
+            .iter()
+            .filter(|(c, _)| c != &commit)
+            .flat_map(|(_, r)| {
+                r.volumes
+                    .iter()
+                    .find(|(k, _)| k == &volume_name)
+                    .map(|(_, v)| v)
             })
             .next()
     })

--- a/helios-state/src/worker/tests/migrations.rs
+++ b/helios-state/src/worker/tests/migrations.rs
@@ -67,6 +67,106 @@ fn it_finds_a_workflow_for_migrating_networks() {
 }
 
 #[test]
+fn it_finds_a_workflow_for_migrating_networks_with_tagged_image() {
+    init_tracing();
+    assert_workflow(
+        json!({
+            "uuid": "my-device-uuid",
+            "apps": {
+                "my-app-uuid": {
+                    "id": 1,
+                    "name": "my-app",
+                    "releases": {
+                        "old-release": {
+                            "installed": true,
+                            "services": {
+                                "my-service": {
+                                    "id": 1,
+                                    "image": "ubuntu:latest",
+                                    "started": true,
+                                    "oci": running_container("old-release_my-service"),
+                                    "config": {
+                                        "networks": {
+                                            "my-network": {}
+                                        }
+                                    },
+                                },
+                            },
+                            "networks": {
+                                "my-network": {
+                                    "oci_name": "my-app-uuid_my-network",
+                                    "config": {
+                                        "driver": "bridge",
+                                        "enable_ipv6": false,
+                                    },
+                                },
+                            },
+                        }
+                    }
+                }
+            },
+            "images": {
+                "ubuntu:latest" : {
+                    "oci_id": "abcde",
+                    "download_progress": 100,
+                }
+            }
+        }),
+        json!({
+            "uuid": "my-device-uuid",
+            "apps": {
+                "my-app-uuid": {
+                    "id": 1,
+                    "name": "my-app",
+                    "releases": {
+                        "new-release": {
+                            "installed": true,
+                            "services": {
+                                "my-service": {
+                                    "id": 1,
+                                    "image": "ubuntu:latest",
+                                    "started": true,
+                                    "config": {
+                                        "networks": {
+                                            "my-network": {}
+                                        }
+                                    },
+                                },
+                            },
+                            "networks": {
+                                "my-network": {
+                                    "config": {
+                                        "driver": "overlay",
+                                        "enable_ipv6": true,
+                                    },
+                                },
+                            },
+                        }
+                    }
+                }
+            },
+        }),
+        dag!(
+            seq!("initialize release 'new-release' for app with uuid 'my-app-uuid'"),
+            seq!(
+                "stop service 'my-service' for release 'old-release'",
+                "uninstall service 'my-service' for release 'old-release'",
+            )
+        ) + par!(
+            "initialize service 'my-service' for release 'new-release'",
+            "remove network 'my-network' for app 'my-app-uuid'"
+        ) + par!(
+            "remove release 'old-release' for app with uuid 'my-app-uuid'",
+            "setup network 'my-network' for app 'my-app-uuid'"
+        ) + seq!(
+            "install service 'my-service' for release 'new-release'",
+            "start service 'my-service' for release 'new-release'",
+            "finish release 'new-release' for app with uuid 'my-app-uuid'",
+        ),
+    );
+}
+
+#[test]
 fn it_finds_a_workflow_for_migrating_volumes() {
     init_tracing();
     assert_workflow(

--- a/helios-state/src/worker/tests/migrations.rs
+++ b/helios-state/src/worker/tests/migrations.rs
@@ -134,6 +134,109 @@ fn it_finds_a_workflow_for_migrating_volumes() {
 }
 
 #[test]
+fn it_finds_a_workflow_for_migrating_networks_with_linked_services() {
+    init_tracing();
+    assert_workflow(
+        json!({
+            "uuid": "my-device-uuid",
+            "apps": {
+                "my-app-uuid": {
+                    "id": 1,
+                    "name": "my-app",
+                    "releases": {
+                        "old-release": {
+                            "installed": true,
+                            "services": {
+                                "my-svc": {
+                                    "id": 1,
+                                    // same digest as target, different URI name
+                                    "image": "registry2.balena-cloud.com/v2/oldsvc@sha256:a111111111111111111111111111111111111111111111111111111111111111",
+                                    "started": true,
+                                    "oci": running_container("old-release_my-svc"),
+                                    "config": {
+                                        "networks": {"my-net": {}}
+                                    },
+                                },
+                            },
+                            "networks": {
+                                "my-net": {
+                                    "oci_name": "my-app-uuid_my-net",
+                                    "config": {
+                                        "driver_opts": {
+                                            "foo": "bar"
+                                        },
+                                    },
+                                },
+                            },
+                        }
+                    }
+                }
+            },
+            "images": {
+                "registry2.balena-cloud.com/v2/oldsvc@sha256:a111111111111111111111111111111111111111111111111111111111111111": {
+                    "config": {},
+                    "download_progress": 100,
+                    "oci_id": "111"
+                },
+            },
+        }),
+        json!({
+            "uuid": "my-device-uuid",
+            "apps": {
+                "my-app-uuid": {
+                    "id": 1,
+                    "name": "my-app",
+                    "releases": {
+                        "new-release": {
+                            "installed": true,
+                            "services": {
+                                "my-svc": {
+                                    "id": 1,
+                                    "image": "registry2.balena-cloud.com/v2/newsvc@sha256:a111111111111111111111111111111111111111111111111111111111111111",
+                                    "started": true,
+                                    "config": {
+                                        "networks": {"my-net": {}}
+                                    },
+                                },
+                            },
+                            "networks": {
+                                "my-net": {
+                                    "config": {
+                                        "driver_opts": {
+                                            "foo": "bar"
+                                        },
+                                    },
+                                },
+                            },
+                        }
+                    }
+                }
+            },
+        }),
+        seq!("initialize release 'new-release' for app with uuid 'my-app-uuid'",)
+            + par!(
+                "setup network 'my-net' for app 'my-app-uuid'",
+                "initialize service 'my-svc' for release 'new-release'"
+            )
+            + seq!(
+                "tag image 'registry2.balena-cloud.com/v2/oldsvc@sha256:a111111111111111111111111111111111111111111111111111111111111111' as 'registry2.balena-cloud.com/v2/newsvc@sha256:a111111111111111111111111111111111111111111111111111111111111111'"
+            )
+            + dag!(
+                seq!("remove data for network 'my-net' from release 'old-release'"),
+                par!(
+                    "remove data for 'my-svc' for release 'old-release'",
+                    "migrate service 'my-svc' to release 'new-release'"
+                )
+            )
+            + par!(
+                "remove release 'old-release' for app with uuid 'my-app-uuid'",
+                "update image metadata for service 'my-svc' of release 'new-release'"
+            )
+            + seq!("finish release 'new-release' for app with uuid 'my-app-uuid'"),
+    );
+}
+
+#[test]
 fn it_finds_a_workflow_for_migrating_networks_and_volumes() {
     init_tracing();
     assert_workflow(

--- a/helios-state/src/worker/tests/migrations.rs
+++ b/helios-state/src/worker/tests/migrations.rs
@@ -257,7 +257,7 @@ fn it_should_not_migrate_a_service_that_links_to_a_changing_network() {
                                     "started": true,
                                     "oci": running_container("old-release_my-svc"),
                                     "config": {
-                                        "networks": {"my-network": {}}
+                                        "networks": {"my-net": {}}
                                     },
                                 },
                             },
@@ -298,7 +298,7 @@ fn it_should_not_migrate_a_service_that_links_to_a_changing_network() {
                                     "image": "registry2.balena-cloud.com/v2/newsvc@sha256:a111111111111111111111111111111111111111111111111111111111111111",
                                     "started": true,
                                     "config": {
-                                        "networks": {"my-network": {}}
+                                        "networks": {"my-net": {}}
                                     },
                                 },
                             },
@@ -316,26 +316,25 @@ fn it_should_not_migrate_a_service_that_links_to_a_changing_network() {
                 }
             },
         }),
-        seq!("initialize release 'new-release' for app with uuid 'my-app-uuid'",)
-            + par!(
-                "setup network 'my-net' for app 'my-app-uuid'",
-                "initialize service 'my-svc' for release 'new-release'"
+        dag!(
+            seq!("initialize release 'new-release' for app with uuid 'my-app-uuid'"),
+            seq!(
+                "stop service 'my-svc' for release 'old-release'",
+                "uninstall service 'my-svc' for release 'old-release'"
             )
-            + seq!(
-                "tag image 'registry2.balena-cloud.com/v2/oldsvc@sha256:a111111111111111111111111111111111111111111111111111111111111111' as 'registry2.balena-cloud.com/v2/newsvc@sha256:a111111111111111111111111111111111111111111111111111111111111111'"
-            )
-            + dag!(
-                seq!("remove data for network 'my-net' from release 'old-release'"),
-                par!(
-                    "remove data for 'my-svc' for release 'old-release'",
-                    "migrate service 'my-svc' to release 'new-release'"
-                )
-            )
-            + par!(
-                "remove release 'old-release' for app with uuid 'my-app-uuid'",
-                "update image metadata for service 'my-svc' of release 'new-release'"
-            )
-            + seq!("finish release 'new-release' for app with uuid 'my-app-uuid'"),
+        ) + par!(
+            "initialize service 'my-svc' for release 'new-release'",
+            "remove network 'my-net' for app 'my-app-uuid'",
+        ) + seq!(
+            "tag image 'registry2.balena-cloud.com/v2/oldsvc@sha256:a111111111111111111111111111111111111111111111111111111111111111' as 'registry2.balena-cloud.com/v2/newsvc@sha256:a111111111111111111111111111111111111111111111111111111111111111'"
+        ) + par!(
+            "remove release 'old-release' for app with uuid 'my-app-uuid'",
+            "setup network 'my-net' for app 'my-app-uuid'"
+        ) + seq!(
+            "install service 'my-svc' for release 'new-release'",
+            "start service 'my-svc' for release 'new-release'",
+            "finish release 'new-release' for app with uuid 'my-app-uuid'"
+        ),
     );
 }
 

--- a/helios-state/src/worker/tests/migrations.rs
+++ b/helios-state/src/worker/tests/migrations.rs
@@ -237,6 +237,109 @@ fn it_finds_a_workflow_for_migrating_networks_with_linked_services() {
 }
 
 #[test]
+fn it_should_not_migrate_a_service_that_links_to_a_changing_network() {
+    init_tracing();
+    assert_workflow(
+        json!({
+            "uuid": "my-device-uuid",
+            "apps": {
+                "my-app-uuid": {
+                    "id": 1,
+                    "name": "my-app",
+                    "releases": {
+                        "old-release": {
+                            "installed": true,
+                            "services": {
+                                "my-svc": {
+                                    "id": 1,
+                                    // same digest as target, different URI name
+                                    "image": "registry2.balena-cloud.com/v2/oldsvc@sha256:a111111111111111111111111111111111111111111111111111111111111111",
+                                    "started": true,
+                                    "oci": running_container("old-release_my-svc"),
+                                    "config": {
+                                        "networks": {"my-network": {}}
+                                    },
+                                },
+                            },
+                            "networks": {
+                                "my-net": {
+                                    "oci_name": "my-app-uuid_my-net",
+                                    "config": {
+                                        "driver_opts": {
+                                            "foo": "bar"
+                                        },
+                                    },
+                                },
+                            },
+                        }
+                    }
+                }
+            },
+            "images": {
+                "registry2.balena-cloud.com/v2/oldsvc@sha256:a111111111111111111111111111111111111111111111111111111111111111": {
+                    "config": {},
+                    "download_progress": 100,
+                    "oci_id": "111"
+                },
+            },
+        }),
+        json!({
+            "uuid": "my-device-uuid",
+            "apps": {
+                "my-app-uuid": {
+                    "id": 1,
+                    "name": "my-app",
+                    "releases": {
+                        "new-release": {
+                            "installed": true,
+                            "services": {
+                                "my-svc": {
+                                    "id": 1,
+                                    "image": "registry2.balena-cloud.com/v2/newsvc@sha256:a111111111111111111111111111111111111111111111111111111111111111",
+                                    "started": true,
+                                    "config": {
+                                        "networks": {"my-network": {}}
+                                    },
+                                },
+                            },
+                            "networks": {
+                                "my-net": {
+                                    "config": {
+                                        "driver_opts": {
+                                            "foo": "baz"
+                                        },
+                                    },
+                                },
+                            },
+                        }
+                    }
+                }
+            },
+        }),
+        seq!("initialize release 'new-release' for app with uuid 'my-app-uuid'",)
+            + par!(
+                "setup network 'my-net' for app 'my-app-uuid'",
+                "initialize service 'my-svc' for release 'new-release'"
+            )
+            + seq!(
+                "tag image 'registry2.balena-cloud.com/v2/oldsvc@sha256:a111111111111111111111111111111111111111111111111111111111111111' as 'registry2.balena-cloud.com/v2/newsvc@sha256:a111111111111111111111111111111111111111111111111111111111111111'"
+            )
+            + dag!(
+                seq!("remove data for network 'my-net' from release 'old-release'"),
+                par!(
+                    "remove data for 'my-svc' for release 'old-release'",
+                    "migrate service 'my-svc' to release 'new-release'"
+                )
+            )
+            + par!(
+                "remove release 'old-release' for app with uuid 'my-app-uuid'",
+                "update image metadata for service 'my-svc' of release 'new-release'"
+            )
+            + seq!("finish release 'new-release' for app with uuid 'my-app-uuid'"),
+    );
+}
+
+#[test]
 fn it_finds_a_workflow_for_migrating_networks_and_volumes() {
     init_tracing();
     assert_workflow(

--- a/helios-state/src/worker/tests/migrations.rs
+++ b/helios-state/src/worker/tests/migrations.rs
@@ -134,6 +134,351 @@ fn it_finds_a_workflow_for_migrating_volumes() {
 }
 
 #[test]
+fn it_finds_a_workflow_for_migrating_volumes_with_linked_services() {
+    init_tracing();
+    assert_workflow(
+        json!({
+            "uuid": "my-device-uuid",
+            "apps": {
+                "my-app-uuid": {
+                    "id": 1,
+                    "name": "my-app",
+                    "releases": {
+                        "old-release": {
+                            "installed": true,
+                            "services": {
+                                "my-svc": {
+                                    "id": 1,
+                                    // same digest as target, different URI name
+                                    "image": "registry2.balena-cloud.com/v2/oldsvc@sha256:a111111111111111111111111111111111111111111111111111111111111111",
+                                    "started": true,
+                                    "oci": running_container("old-release_my-svc"),
+                                    "config": {
+                                        "volumes": [
+                                            {
+                                                "type": "volume",
+                                                "source": "my-vol",
+                                                "target": "/data"
+                                            }
+                                        ]
+                                    },
+                                },
+                            },
+                            "volumes": {
+                                "my-vol": {
+                                    "oci_name": "my-app-uuid_my-vol",
+                                },
+                            },
+                        }
+                    }
+                }
+            },
+            "images": {
+                "registry2.balena-cloud.com/v2/oldsvc@sha256:a111111111111111111111111111111111111111111111111111111111111111": {
+                    "config": {},
+                    "download_progress": 100,
+                    "oci_id": "111"
+                },
+            },
+        }),
+        json!({
+            "uuid": "my-device-uuid",
+            "apps": {
+                "my-app-uuid": {
+                    "id": 1,
+                    "name": "my-app",
+                    "releases": {
+                        "new-release": {
+                            "installed": true,
+                            "services": {
+                                "my-svc": {
+                                    "id": 1,
+                                    "image": "registry2.balena-cloud.com/v2/newsvc@sha256:a111111111111111111111111111111111111111111111111111111111111111",
+                                    "started": true,
+                                    "config": {
+                                        "volumes": [
+                                            {
+                                                "type": "volume",
+                                                "source": "my-vol",
+                                                "target": "/data"
+                                            }
+                                        ]
+                                    },
+                                },
+                            },
+                            "volumes": {
+                                "my-vol": {},
+                            },
+                        }
+                    }
+                }
+            },
+        }),
+        seq!("initialize release 'new-release' for app with uuid 'my-app-uuid'",)
+            + par!(
+                "initialize service 'my-svc' for release 'new-release'",
+                "setup volume 'my-vol' for app 'my-app-uuid'"
+            )
+            + seq!(
+                "tag image 'registry2.balena-cloud.com/v2/oldsvc@sha256:a111111111111111111111111111111111111111111111111111111111111111' as 'registry2.balena-cloud.com/v2/newsvc@sha256:a111111111111111111111111111111111111111111111111111111111111111'"
+            )
+            + dag!(
+                par!(
+                    "remove data for 'my-svc' for release 'old-release'",
+                    "migrate service 'my-svc' to release 'new-release'"
+                ),
+                seq!("remove data for volume 'my-vol' from release 'old-release'"),
+            )
+            + par!(
+                "remove release 'old-release' for app with uuid 'my-app-uuid'",
+                "update image metadata for service 'my-svc' of release 'new-release'"
+            )
+            + seq!("finish release 'new-release' for app with uuid 'my-app-uuid'"),
+    );
+}
+
+#[test]
+fn it_should_not_migrate_a_service_that_links_to_a_changing_volume() {
+    init_tracing();
+    assert_workflow(
+        json!({
+            "uuid": "my-device-uuid",
+            "apps": {
+                "my-app-uuid": {
+                    "id": 1,
+                    "name": "my-app",
+                    "releases": {
+                        "old-release": {
+                            "installed": true,
+                            "services": {
+                                "my-svc": {
+                                    "id": 1,
+                                    // same digest as target, different URI name
+                                    "image": "registry2.balena-cloud.com/v2/oldsvc@sha256:a111111111111111111111111111111111111111111111111111111111111111",
+                                    "started": true,
+                                    "oci": running_container("old-release_my-svc"),
+                                    "config": {
+                                        "volumes": [
+                                            {
+                                                "type": "volume",
+                                                "source": "my-vol",
+                                                "target": "/data"
+                                            }
+                                        ]
+                                    },
+                                },
+                            },
+                            "volumes": {
+                                "my-vol": {
+                                    "oci_name": "my-app-uuid_my-vol",
+                                },
+                            },
+                        }
+                    }
+                }
+            },
+            "images": {
+                "registry2.balena-cloud.com/v2/oldsvc@sha256:a111111111111111111111111111111111111111111111111111111111111111": {
+                    "config": {},
+                    "download_progress": 100,
+                    "oci_id": "111"
+                },
+            },
+        }),
+        json!({
+            "uuid": "my-device-uuid",
+            "apps": {
+                "my-app-uuid": {
+                    "id": 1,
+                    "name": "my-app",
+                    "releases": {
+                        "new-release": {
+                            "installed": true,
+                            "services": {
+                                "my-svc": {
+                                    "id": 1,
+                                    "image": "registry2.balena-cloud.com/v2/newsvc@sha256:a111111111111111111111111111111111111111111111111111111111111111",
+                                    "started": true,
+                                    "config": {
+                                        "volumes": [
+                                            {
+                                                "type": "volume",
+                                                "source": "my-vol",
+                                                "target": "/data"
+                                            }
+                                        ]
+                                    },
+                                },
+                            },
+                            "volumes": {
+                                "my-vol": {
+                                    "config": {
+                                        "labels": {
+                                            "io.balena.foo": "bar"
+                                        }
+                                    },
+                                },
+                            },
+                        }
+                    }
+                }
+            },
+        }),
+        dag!(
+            seq!("initialize release 'new-release' for app with uuid 'my-app-uuid'"),
+            seq!(
+                "stop service 'my-svc' for release 'old-release'",
+                "uninstall service 'my-svc' for release 'old-release'"
+            )
+        ) + par!(
+            "initialize service 'my-svc' for release 'new-release'",
+            "remove volume 'my-vol' for app 'my-app-uuid'",
+        ) + seq!(
+            "tag image 'registry2.balena-cloud.com/v2/oldsvc@sha256:a111111111111111111111111111111111111111111111111111111111111111' as 'registry2.balena-cloud.com/v2/newsvc@sha256:a111111111111111111111111111111111111111111111111111111111111111'"
+        ) + par!(
+            "remove release 'old-release' for app with uuid 'my-app-uuid'",
+            "setup volume 'my-vol' for app 'my-app-uuid'"
+        ) + seq!(
+            "install service 'my-svc' for release 'new-release'",
+            "start service 'my-svc' for release 'new-release'",
+            "finish release 'new-release' for app with uuid 'my-app-uuid'"
+        ),
+    );
+}
+
+#[test]
+fn it_should_not_migrate_a_service_that_links_to_a_changing_volume_and_network() {
+    init_tracing();
+    assert_workflow(
+        json!({
+            "uuid": "my-device-uuid",
+            "apps": {
+                "my-app-uuid": {
+                    "id": 1,
+                    "name": "my-app",
+                    "releases": {
+                        "old-release": {
+                            "installed": true,
+                            "services": {
+                                "my-svc": {
+                                    "id": 1,
+                                    // same digest as target, different URI name
+                                    "image": "registry2.balena-cloud.com/v2/oldsvc@sha256:a111111111111111111111111111111111111111111111111111111111111111",
+                                    "started": true,
+                                    "oci": running_container("old-release_my-svc"),
+                                    "config": {
+                                        "networks": {"my-net": {}},
+                                        "volumes": [
+                                            {
+                                                "type": "volume",
+                                                "source": "my-vol",
+                                                "target": "/data"
+                                            }
+                                        ]
+                                    },
+                                },
+                            },
+                            "networks": {
+                                "my-net": {
+                                    "oci_name": "my-app-uuid_my-net",
+                                    "config": {
+                                        "driver_opts": {
+                                            "foo": "bar"
+                                        },
+                                    },
+                                },
+                            },
+                            "volumes": {
+                                "my-vol": {
+                                    "oci_name": "my-app-uuid_my-vol",
+                                },
+                            },
+                        }
+                    }
+                }
+            },
+            "images": {
+                "registry2.balena-cloud.com/v2/oldsvc@sha256:a111111111111111111111111111111111111111111111111111111111111111": {
+                    "config": {},
+                    "download_progress": 100,
+                    "oci_id": "111"
+                },
+            },
+        }),
+        json!({
+            "uuid": "my-device-uuid",
+            "apps": {
+                "my-app-uuid": {
+                    "id": 1,
+                    "name": "my-app",
+                    "releases": {
+                        "new-release": {
+                            "installed": true,
+                            "services": {
+                                "my-svc": {
+                                    "id": 1,
+                                    "image": "registry2.balena-cloud.com/v2/newsvc@sha256:a111111111111111111111111111111111111111111111111111111111111111",
+                                    "started": true,
+                                    "config": {
+                                        "networks": {"my-net": {}},
+                                        "volumes": [
+                                            {
+                                                "type": "volume",
+                                                "source": "my-vol",
+                                                "target": "/data"
+                                            }
+                                        ]
+                                    },
+                                },
+                            },
+                            "networks": {
+                                "my-net": {
+                                    "config": {
+                                        "driver_opts": {
+                                            "foo": "baz"
+                                        },
+                                    },
+                                },
+                            },
+                            "volumes": {
+                                "my-vol": {
+                                    "config": {
+                                        "labels": {
+                                            "io.balena.foo": "bar"
+                                        }
+                                    },
+                                },
+                            },
+                        }
+                    }
+                }
+            },
+        }),
+        dag!(
+            seq!("initialize release 'new-release' for app with uuid 'my-app-uuid'"),
+            seq!(
+                "stop service 'my-svc' for release 'old-release'",
+                "uninstall service 'my-svc' for release 'old-release'"
+            )
+        ) + par!(
+            "initialize service 'my-svc' for release 'new-release'",
+            "remove network 'my-net' for app 'my-app-uuid'",
+            "remove volume 'my-vol' for app 'my-app-uuid'",
+        ) + seq!(
+            "tag image 'registry2.balena-cloud.com/v2/oldsvc@sha256:a111111111111111111111111111111111111111111111111111111111111111' as 'registry2.balena-cloud.com/v2/newsvc@sha256:a111111111111111111111111111111111111111111111111111111111111111'"
+        ) + par!(
+            "remove release 'old-release' for app with uuid 'my-app-uuid'",
+            "setup network 'my-net' for app 'my-app-uuid'",
+            "setup volume 'my-vol' for app 'my-app-uuid'"
+        ) + seq!(
+            "install service 'my-svc' for release 'new-release'",
+            "start service 'my-svc' for release 'new-release'",
+            "finish release 'new-release' for app with uuid 'my-app-uuid'"
+        ),
+    );
+}
+
+#[test]
 fn it_finds_a_workflow_for_migrating_networks_with_linked_services() {
     init_tracing();
     assert_workflow(

--- a/helios-state/src/worker/tests/networks.rs
+++ b/helios-state/src/worker/tests/networks.rs
@@ -240,8 +240,11 @@ fn it_finds_a_workflow_for_updating_networks() {
             "my-app-uuid",
             seq!(
                 "stop service 'my-service' for release 'my-release-uuid'",
-                "remove container for service 'my-service' for release 'my-release-uuid'",
+                "uninstall service 'my-service' for release 'my-release-uuid'",
+            ) + par!(
                 "remove network 'my-network' for app 'my-app-uuid'",
+                "initialize service 'my-service' for release 'my-release-uuid'"
+            ) + seq!(
                 "setup network 'my-network' for app 'my-app-uuid'",
                 "install service 'my-service' for release 'my-release-uuid'",
                 "start service 'my-service' for release 'my-release-uuid'",

--- a/helios-state/src/worker/tests/volumes.rs
+++ b/helios-state/src/worker/tests/volumes.rs
@@ -372,8 +372,11 @@ fn it_finds_a_workflow_for_updating_a_volume_in_use_by_a_service() {
             "my-app-uuid",
             seq!(
                 "stop service 'my-service' for release 'my-release-uuid'",
-                "remove container for service 'my-service' for release 'my-release-uuid'",
+                "uninstall service 'my-service' for release 'my-release-uuid'",
+            ) + par!(
+                "initialize service 'my-service' for release 'my-release-uuid'",
                 "remove volume 'my-volume' for app 'my-app-uuid'",
+            ) + seq!(
                 "setup volume 'my-volume' for app 'my-app-uuid'",
                 "install service 'my-service' for release 'my-release-uuid'",
                 "start service 'my-service' for release 'my-release-uuid'",

--- a/helios-util/src/crypto.rs
+++ b/helios-util/src/crypto.rs
@@ -1,8 +1,55 @@
+use std::fmt::Write as _;
+
 use sha2::{Digest as _, Sha256};
 
 pub fn sha256_hex_digest<D: AsRef<[u8]>>(data: D) -> String {
     let mut hasher = Sha256::default();
     hasher.update(data.as_ref());
     let digest = hasher.finalize();
-    format!("{digest:x}")
+    digest
+        .iter()
+        .fold(String::with_capacity(digest.len() * 2), |mut s, b| {
+            write!(s, "{b:02x}").unwrap();
+            s
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // These vectors are standard SHA-256 outputs and must remain stable —
+    // helios-store paths and helios-remote provisioning IDs are derived from
+    // them, so any change here would invalidate on-disk state on existing
+    // devices.
+    #[test]
+    fn sha256_hex_digest_matches_known_vectors() {
+        assert_eq!(
+            sha256_hex_digest(""),
+            "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+        );
+        assert_eq!(
+            sha256_hex_digest("abc"),
+            "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
+        );
+        assert_eq!(
+            sha256_hex_digest("hello world"),
+            "b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9"
+        );
+        assert_eq!(
+            sha256_hex_digest("https://api.balena-cloud.com"),
+            "6fd309b6db563863d07e75805cd2f98c1a7ca157287b902a223b21a5295f1a58"
+        );
+    }
+
+    #[test]
+    fn sha256_hex_digest_output_is_64_lowercase_hex_chars() {
+        let digest = sha256_hex_digest([0u8; 1024]);
+        assert_eq!(digest.len(), 64);
+        assert!(
+            digest
+                .chars()
+                .all(|c| c.is_ascii_hexdigit() && !c.is_ascii_uppercase())
+        );
+    }
 }


### PR DESCRIPTION
There were a few issues with updates including services linking to networks. 
- If the service was not changing, the planner was assuming it could be migrated, even if the network/volume existed. Remove network/volume tasks now also trigger a removal of any linked services to ensure requirements are met. 
- This also fixes an issue where a new network/volume would always be created in the new release even if the entity from the previous release had a different configuration
- Finally it also fixes an issue where a service migration was being added to the plan even if the target release did not exist yet