### PR TITLE
Improve field tracking for podman

### DIFF
--- a/helios-oci/src/container.rs
+++ b/helios-oci/src/container.rs
@@ -252,7 +252,8 @@ impl<N> TryFrom<ContainerInspectResponse> for LocalContainer<N> {
         let cgroup = host_config
             .as_mut()
             .and_then(|hc| hc.cgroupns_mode.take())
-            .and_then(|m| Cgroup::try_from(m).ok());
+            .map(Cgroup::from)
+            .unwrap_or_default();
         let cgroup_parent = host_config
             .as_mut()
             .and_then(|hc| hc.cgroup_parent.take())
@@ -264,15 +265,15 @@ impl<N> TryFrom<ContainerInspectResponse> for LocalContainer<N> {
         let cpu_rt_period = host_config
             .as_mut()
             .and_then(|hc| hc.cpu_realtime_period.take())
-            .filter(|n| *n != 0);
+            .unwrap_or(0);
         let cpu_rt_runtime = host_config
             .as_mut()
             .and_then(|hc| hc.cpu_realtime_runtime.take())
-            .filter(|n| *n != 0);
+            .unwrap_or(0);
         let cpu_shares = host_config
             .as_mut()
             .and_then(|hc| hc.cpu_shares.take())
-            .filter(|n| *n != 0);
+            .unwrap_or(0);
         let init = host_config.as_mut().and_then(|hc| hc.init.take());
         // Only recognize `none`/`host` from host_config: for user networks Docker also
         // populates `network_mode` with the first network name, which would otherwise
@@ -319,15 +320,15 @@ impl<N> TryFrom<ContainerInspectResponse> for LocalContainer<N> {
         let mem_limit = host_config
             .as_mut()
             .and_then(|hc| hc.memory.take())
-            .filter(|n| *n != 0);
+            .unwrap_or(0);
         let mem_reservation = host_config
             .as_mut()
             .and_then(|hc| hc.memory_reservation.take())
-            .filter(|n| *n != 0);
+            .unwrap_or(0);
         let nano_cpus = host_config
             .as_mut()
             .and_then(|hc| hc.nano_cpus.take())
-            .filter(|n| *n != 0);
+            .unwrap_or(0);
         let oom_score_adj = host_config
             .as_mut()
             .and_then(|hc| hc.oom_score_adj.take())
@@ -513,10 +514,11 @@ pub struct ContainerState {
 }
 
 /// Cgroup namespace mode for a container.
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Default)]
 #[serde(rename_all = "lowercase")]
 pub enum Cgroup {
     Host,
+    #[default]
     Private,
 }
 
@@ -529,18 +531,22 @@ impl From<Cgroup> for bollard::models::HostConfigCgroupnsModeEnum {
     }
 }
 
-impl TryFrom<bollard::models::HostConfigCgroupnsModeEnum> for Cgroup {
-    type Error = ();
-    fn try_from(
-        value: bollard::models::HostConfigCgroupnsModeEnum,
-    ) -> std::result::Result<Self, Self::Error> {
+impl From<bollard::models::HostConfigCgroupnsModeEnum> for Cgroup {
+    fn from(value: bollard::models::HostConfigCgroupnsModeEnum) -> Self {
         use bollard::models::HostConfigCgroupnsModeEnum::*;
         match value {
-            HOST => Ok(Cgroup::Host),
-            PRIVATE => Ok(Cgroup::Private),
-            EMPTY => Err(()),
+            HOST => Cgroup::Host,
+            PRIVATE | EMPTY => Cgroup::Private,
         }
     }
+}
+
+fn is_zero(n: &i64) -> bool {
+    *n == 0
+}
+
+fn non_zero(n: i64) -> Option<i64> {
+    (n != 0).then_some(n)
 }
 
 /// Docker compose restart policy for a container.
@@ -888,7 +894,7 @@ impl TryFrom<bollard::models::Mount> for Mount {
 #[serde(default)]
 pub struct ContainerConfig {
     /// Cgroup namespace mode (`host` or `private`)
-    pub cgroup: Option<Cgroup>,
+    pub cgroup: Cgroup,
 
     /// Path to cgroups under which the container's cgroup is created
     pub cgroup_parent: Option<String>,
@@ -900,13 +906,16 @@ pub struct ContainerConfig {
     pub cpuset: Option<String>,
 
     /// Real-time CPU period in microseconds.
-    pub cpu_rt_period: Option<i64>,
+    #[serde(skip_serializing_if = "is_zero")]
+    pub cpu_rt_period: i64,
 
     /// Real-time CPU runtime in microseconds (must be <= `cpu_rt_period`).
-    pub cpu_rt_runtime: Option<i64>,
+    #[serde(skip_serializing_if = "is_zero")]
+    pub cpu_rt_runtime: i64,
 
     /// CPU shares (relative weight vs other containers; default 1024)
-    pub cpu_shares: Option<i64>,
+    #[serde(skip_serializing_if = "is_zero")]
+    pub cpu_shares: i64,
 
     /// NIS domain name to use for the container.
     pub domainname: Option<String>,
@@ -927,14 +936,17 @@ pub struct ContainerConfig {
     pub labels: HashMap<String, String>,
 
     /// Memory limit in bytes
-    pub mem_limit: Option<i64>,
+    #[serde(skip_serializing_if = "is_zero")]
+    pub mem_limit: i64,
 
     /// Memory reservation in bytes
-    pub mem_reservation: Option<i64>,
+    #[serde(skip_serializing_if = "is_zero")]
+    pub mem_reservation: i64,
 
     /// CPU quota in nanoseconds-of-CPU-per-second (1 CPU = 1_000_000_000),
     /// Compose's fractional `cpus` is stored here after the `* 1e9` conversion
-    pub nano_cpus: Option<i64>,
+    #[serde(skip_serializing_if = "is_zero")]
+    pub nano_cpus: i64,
 
     /// Run container with extended privileges.
     #[serde(skip_serializing_if = "std::ops::Not::not")]
@@ -1137,20 +1149,20 @@ impl From<ContainerConfig> for ContainerCreateBody {
             Some(volumes.into_iter().map(Into::into).collect())
         };
 
-        let cgroupns_mode = cgroup.map(Into::into);
+        let cgroupns_mode = Some(cgroup.into());
 
         let host_config = bollard::config::HostConfig {
             cgroup_parent,
             cgroupns_mode,
             cpuset_cpus: cpuset,
-            cpu_realtime_period: cpu_rt_period,
-            cpu_realtime_runtime: cpu_rt_runtime,
-            cpu_shares,
+            cpu_realtime_period: non_zero(cpu_rt_period),
+            cpu_realtime_runtime: non_zero(cpu_rt_runtime),
+            cpu_shares: non_zero(cpu_shares),
             init,
-            memory: mem_limit,
-            memory_reservation: mem_reservation,
+            memory: non_zero(mem_limit),
+            memory_reservation: non_zero(mem_reservation),
             mounts: engine_mounts,
-            nano_cpus,
+            nano_cpus: non_zero(nano_cpus),
             network_mode: host_network_mode,
             oom_score_adj,
             pids_limit,
@@ -1371,7 +1383,7 @@ mod tests {
             ..Default::default()
         };
         let c: LocalContainer = resp.try_into().unwrap();
-        assert_eq!(c.config.cgroup, Some(Cgroup::Host));
+        assert_eq!(c.config.cgroup, Cgroup::Host);
         assert_eq!(c.config.cgroup_parent.as_deref(), Some("/custom"));
         assert_eq!(c.config.cpuset.as_deref(), Some("0-3"));
         assert_eq!(c.config.runtime.as_deref(), Some("runc"));
@@ -1387,7 +1399,7 @@ mod tests {
     #[test]
     fn container_create_body_emits_string_fields() {
         let cfg = ContainerConfig {
-            cgroup: Some(Cgroup::Host),
+            cgroup: Cgroup::Host,
             cgroup_parent: Some("/custom".to_string()),
             cpuset: Some("0-3".to_string()),
             domainname: Some("example.com".to_string()),
@@ -1448,12 +1460,12 @@ mod tests {
             ..Default::default()
         };
         let c: LocalContainer = resp.try_into().unwrap();
-        assert_eq!(c.config.cpu_rt_period, Some(1_000_000));
-        assert_eq!(c.config.cpu_rt_runtime, Some(950_000));
-        assert_eq!(c.config.cpu_shares, Some(2048));
-        assert_eq!(c.config.mem_limit, Some(1073741824));
-        assert_eq!(c.config.mem_reservation, Some(536870912));
-        assert_eq!(c.config.nano_cpus, Some(1_500_000_000));
+        assert_eq!(c.config.cpu_rt_period, 1_000_000);
+        assert_eq!(c.config.cpu_rt_runtime, 950_000);
+        assert_eq!(c.config.cpu_shares, 2048);
+        assert_eq!(c.config.mem_limit, 1073741824);
+        assert_eq!(c.config.mem_reservation, 536870912);
+        assert_eq!(c.config.nano_cpus, 1_500_000_000);
         assert_eq!(c.config.oom_score_adj, Some(-500));
         assert_eq!(c.config.pids_limit, Some(100));
         assert_eq!(c.config.shm_size, Some(67108864));
@@ -1463,12 +1475,12 @@ mod tests {
     #[test]
     fn container_create_body_emits_number_host_fields() {
         let cfg = ContainerConfig {
-            cpu_rt_period: Some(1_000_000),
-            cpu_rt_runtime: Some(950_000),
-            cpu_shares: Some(2048),
-            mem_limit: Some(1073741824),
-            mem_reservation: Some(536870912),
-            nano_cpus: Some(1_500_000_000),
+            cpu_rt_period: 1_000_000,
+            cpu_rt_runtime: 950_000,
+            cpu_shares: 2048,
+            mem_limit: 1073741824,
+            mem_reservation: 536870912,
+            nano_cpus: 1_500_000_000,
             oom_score_adj: Some(-500),
             pids_limit: Some(100),
             shm_size: Some(67108864),
@@ -1490,9 +1502,10 @@ mod tests {
     }
 
     #[test]
-    fn inspect_filters_defaults_to_none() {
-        // Engine reports `""` and `0` for fields the user didn't set;
-        // the inspect path collapses those sentinels to `None` so target
+    fn inspect_collapses_default_sentinels() {
+        // Engine reports `""` and `0` for fields the user didn't set; the
+        // inspect path collapses those sentinels to the field's default
+        // (`None` for string options, `0` for numeric fields) so target
         // round-trip is stable without LABEL_CONFIG_FIELDS tracking.
         let resp = ContainerInspectResponse {
             id: Some("cid".to_string()),
@@ -1526,13 +1539,13 @@ mod tests {
         let c: LocalContainer = resp.try_into().unwrap();
         assert_eq!(c.config.cgroup_parent, None);
         assert_eq!(c.config.cpuset, None);
-        assert_eq!(c.config.cpu_rt_period, None);
-        assert_eq!(c.config.cpu_rt_runtime, None);
-        assert_eq!(c.config.cpu_shares, None);
+        assert_eq!(c.config.cpu_rt_period, 0);
+        assert_eq!(c.config.cpu_rt_runtime, 0);
+        assert_eq!(c.config.cpu_shares, 0);
         assert_eq!(c.config.domainname, None);
-        assert_eq!(c.config.mem_limit, None);
-        assert_eq!(c.config.mem_reservation, None);
-        assert_eq!(c.config.nano_cpus, None);
+        assert_eq!(c.config.mem_limit, 0);
+        assert_eq!(c.config.mem_reservation, 0);
+        assert_eq!(c.config.nano_cpus, 0);
         assert_eq!(c.config.oom_score_adj, None);
         assert_eq!(c.config.userns_mode, None);
         assert_eq!(c.config.uts, None);

--- a/helios-remote-model/src/service/mod.rs
+++ b/helios-remote-model/src/service/mod.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use serde::Deserialize;
+use serde::{Deserialize, Deserializer};
 
 use crate::common_types::{Environment, ImageUri, Value};
 
@@ -60,9 +60,11 @@ pub struct ServiceComposition {
     #[serde(default)]
     pub cpu_shares: Option<i64>,
 
-    /// Fractional CPU count such as `1.5`, stored as nano_cpus on the
-    /// container config (1 cpu = 1_000_000_000 nano_cpus)
-    #[serde(default)]
+    /// Fractional CPU count such as `1.5` (Compose `cpus`). Rejected at
+    /// deserialization time if non-finite, negative, or large enough to
+    /// overflow `i64` when converted to nano_cpus (`* 1_000_000_000`), since
+    /// the engine takes nano_cpus and would otherwise saturate silently.
+    #[serde(default, deserialize_with = "deserialize_cpus")]
     pub cpus: Option<f64>,
 
     #[serde(default)]
@@ -141,6 +143,30 @@ pub struct ServiceComposition {
 
     #[serde(default)]
     pub volumes: VolumesConfig,
+}
+
+fn validate_cpus(cpus: f64) -> Result<f64, String> {
+    if !cpus.is_finite() || cpus < 0.0 {
+        return Err(format!(
+            "`cpus` must be a finite non-negative number, got {cpus}"
+        ));
+    }
+    // Engine takes nano_cpus (i64). Round to nearest to avoid drift on values
+    // like `0.3` whose binary f64 representation is slightly below the rational.
+    if (cpus * 1_000_000_000.0).round() > i64::MAX as f64 {
+        return Err(format!("`cpus` value {cpus} overflows i64 nano_cpus"));
+    }
+    Ok(cpus)
+}
+
+fn deserialize_cpus<'de, D>(deserializer: D) -> Result<Option<f64>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    Option::<f64>::deserialize(deserializer)?
+        .map(validate_cpus)
+        .transpose()
+        .map_err(serde::de::Error::custom)
 }
 
 #[cfg(test)]
@@ -327,6 +353,43 @@ mod tests {
         assert_eq!(comp.pids_limit, Some(100));
         assert_eq!(comp.shm_size, Some(67108864));
         assert_eq!(comp.stop_grace_period, Some(30));
+    }
+
+    #[test]
+    fn validate_cpus_accepts_finite_non_negative() {
+        assert_eq!(validate_cpus(0.0), Ok(0.0));
+        assert_eq!(validate_cpus(0.3), Ok(0.3));
+        assert_eq!(validate_cpus(1.5), Ok(1.5));
+        assert_eq!(validate_cpus(2.0), Ok(2.0));
+    }
+
+    #[test]
+    fn validate_cpus_rejects_non_finite_or_negative() {
+        for bad in [f64::NAN, f64::INFINITY, f64::NEG_INFINITY, -0.5] {
+            let err = validate_cpus(bad).unwrap_err();
+            assert!(
+                err.contains("finite non-negative"),
+                "unexpected error for {bad}: {err}"
+            );
+        }
+    }
+
+    #[test]
+    fn validate_cpus_rejects_overflow() {
+        // 1e10 cpus * 1e9 ns/cpu = 1e19, which exceeds i64::MAX (~9.2e18).
+        let err = validate_cpus(1e10).unwrap_err();
+        assert!(err.contains("overflows i64 nano_cpus"));
+    }
+
+    #[test]
+    fn composition_cpus_rejects_invalid_on_deserialize() {
+        let err = serde_json::from_value::<ServiceComposition>(serde_json::json!({"cpus": -0.5}))
+            .unwrap_err();
+        assert!(err.to_string().contains("finite non-negative"));
+
+        let err = serde_json::from_value::<ServiceComposition>(serde_json::json!({"cpus": 1e10}))
+            .unwrap_err();
+        assert!(err.to_string().contains("overflows i64 nano_cpus"));
     }
 
     #[test]

--- a/helios-state/src/models/service/config.rs
+++ b/helios-state/src/models/service/config.rs
@@ -131,6 +131,17 @@ impl From<oci::ContainerConfig> for ServiceConfig {
                         .aliases
                         .retain(|alias| target_aliases.contains(alias));
 
+                    // The engine assigns a mac_address when one isn't provided.
+                    // The label marks whether the target set one; if absent,
+                    // drop whatever the engine reported so a round-trip
+                    // doesn't see the engine-assigned address as a config change.
+                    if labels
+                        .remove(&format!("{LABEL_CONFIG_NETWORKS}.{net_name}.mac_address"))
+                        .is_none()
+                    {
+                        net_config.mac_address = None;
+                    }
+
                     (net_name, net_config)
                 })
                 .collect();
@@ -250,6 +261,15 @@ impl ServiceConfig {
                     .collect::<json::Value>()
                     .to_string(),
             );
+
+            // mark whether the target set a mac_address so we can drop the
+            // engine-assigned one on read when the composition didn't ask for it
+            if net_config.mac_address.is_some() {
+                labels.insert(
+                    format!("{LABEL_CONFIG_NETWORKS}.{net_name}.mac_address"),
+                    String::new(),
+                );
+            }
 
             let net_id = namespace.to_identifier(&net_name);
 

--- a/helios-state/src/models/service/config.rs
+++ b/helios-state/src/models/service/config.rs
@@ -51,7 +51,6 @@ macro_rules! impl_field_tracking {
 }
 
 impl_field_tracking!(oci::ContainerConfig {
-    cgroup,
     cgroup_parent,
     command,
     hostname,
@@ -297,18 +296,18 @@ mod tests {
     fn preserves_explicit_config_fields_using_label_config_fields() {
         let original = oci::ContainerConfig {
             command: Some(vec!["sleep".to_string(), "infinity".to_string()]),
-            cgroup: Some(oci::Cgroup::Host),
+            cgroup: oci::Cgroup::Host,
             cgroup_parent: Some("/custom".to_string()),
             cpuset: Some("0-3".to_string()),
-            cpu_rt_period: Some(1_000_000),
-            cpu_rt_runtime: Some(950_000),
-            cpu_shares: Some(2048),
+            cpu_rt_period: 1_000_000,
+            cpu_rt_runtime: 950_000,
+            cpu_shares: 2048,
             domainname: Some("example.com".to_string()),
             hostname: Some("my-host".to_string()),
             init: Some(true),
-            mem_limit: Some(1073741824),
-            mem_reservation: Some(536870912),
-            nano_cpus: Some(1_500_000_000),
+            mem_limit: 1073741824,
+            mem_reservation: 536870912,
+            nano_cpus: 1_500_000_000,
             oom_score_adj: Some(-500),
             pids_limit: Some(100),
             runtime: Some("runc".to_string()),
@@ -358,7 +357,6 @@ mod tests {
         let labels = HashMap::from([(LABEL_CONFIG_FIELDS.to_string(), "[]".to_string())]);
         let inspected = oci::ContainerConfig {
             command: Some(vec!["/bin/sh".to_string()]),
-            cgroup: Some(oci::Cgroup::Host),
             hostname: Some("a1b2c3d4e5f6".to_string()),
             init: Some(true),
             pids_limit: Some(100),
@@ -373,7 +371,6 @@ mod tests {
         };
         let svc = ServiceConfig::from(inspected);
         assert_eq!(svc.command, None);
-        assert_eq!(svc.cgroup, None);
         assert_eq!(svc.hostname, None);
         assert_eq!(svc.init, None);
         assert_eq!(svc.pids_limit, None);

--- a/helios-state/src/models/service/config.rs
+++ b/helios-state/src/models/service/config.rs
@@ -52,6 +52,7 @@ macro_rules! impl_field_tracking {
 
 impl_field_tracking!(oci::ContainerConfig {
     cgroup,
+    cgroup_parent,
     command,
     hostname,
     init,
@@ -60,7 +61,9 @@ impl_field_tracking!(oci::ContainerConfig {
     shm_size,
     stop_grace_period,
     stop_signal,
+    oom_score_adj,
     user,
+    uts,
     working_dir,
 });
 

--- a/helios-state/src/models/service/mod.rs
+++ b/helios-state/src/models/service/mod.rs
@@ -251,27 +251,33 @@ impl From<RemoteServiceTarget> for ServiceTarget {
             image: image.into(),
             started: true,
             config: ServiceConfig(ContainerConfig {
-                cgroup: composition.cgroup.map(|c| match c {
-                    RemoteCgroup::Host => Cgroup::Host,
-                    RemoteCgroup::Private => Cgroup::Private,
-                }),
+                cgroup: composition
+                    .cgroup
+                    .map(|c| match c {
+                        RemoteCgroup::Host => Cgroup::Host,
+                        RemoteCgroup::Private => Cgroup::Private,
+                    })
+                    .unwrap_or_default(),
                 cgroup_parent: composition.cgroup_parent,
                 command,
                 cpuset: composition.cpuset,
-                cpu_rt_period: composition.cpu_rt_period,
-                cpu_rt_runtime: composition.cpu_rt_runtime,
-                cpu_shares: composition.cpu_shares,
+                cpu_rt_period: composition.cpu_rt_period.unwrap_or(0),
+                cpu_rt_runtime: composition.cpu_rt_runtime.unwrap_or(0),
+                cpu_shares: composition.cpu_shares.unwrap_or(0),
                 domainname: composition.domainname,
                 environment,
                 hostname: composition.hostname,
                 init: composition.init,
                 labels,
-                mem_limit: composition.mem_limit,
-                mem_reservation: composition.mem_reservation,
+                mem_limit: composition.mem_limit.unwrap_or(0),
+                mem_reservation: composition.mem_reservation.unwrap_or(0),
                 // Compose ships fractional CPU; engine takes nanoseconds-of-CPU-per-second.
                 // Drop NaN/Inf/negative/overflow with a warning rather than producing a
                 // saturated i64 that the engine would silently accept.
-                nano_cpus: composition.cpus.and_then(|c| cpus_to_nano_cpus(id, c)),
+                nano_cpus: composition
+                    .cpus
+                    .and_then(|c| cpus_to_nano_cpus(id, c))
+                    .unwrap_or(0),
                 oom_score_adj: composition.oom_score_adj,
                 pids_limit: composition.pids_limit,
                 privileged: composition.privileged,

--- a/helios-state/src/models/service/mod.rs
+++ b/helios-state/src/models/service/mod.rs
@@ -1,6 +1,5 @@
 use mahler::state::State;
 use serde::{Deserialize, Serialize};
-use tracing::warn;
 
 use crate::labels::LABEL_SERVICE_ID;
 use crate::oci::{
@@ -125,30 +124,6 @@ impl From<Service> for ServiceTarget {
     }
 }
 
-/// Convert a fractional CPU count (compose `cpus`) to nano-CPUs (engine
-/// `nano_cpus`). Returns `None` and logs a warning when the value isn't a
-/// finite non-negative number, or when the converted value would overflow
-/// `i64`. Round to nearest to avoid drift on values like `0.3` whose binary
-/// f64 representation is slightly below the rational.
-fn cpus_to_nano_cpus(svc_id: u32, cpus: f64) -> Option<i64> {
-    if !cpus.is_finite() || cpus < 0.0 {
-        warn!(
-            svc_id,
-            cpus, "ignoring invalid `cpus` value (must be finite and non-negative)"
-        );
-        return None;
-    }
-    let nanos = (cpus * 1_000_000_000.0).round();
-    if nanos > i64::MAX as f64 {
-        warn!(
-            svc_id,
-            cpus, "ignoring `cpus` value that overflows i64 nano_cpus"
-        );
-        return None;
-    }
-    Some(nanos as i64)
-}
-
 impl From<RemoteServiceTarget> for ServiceTarget {
     fn from(service: RemoteServiceTarget) -> Self {
         let RemoteServiceTarget {
@@ -271,12 +246,14 @@ impl From<RemoteServiceTarget> for ServiceTarget {
                 labels,
                 mem_limit: composition.mem_limit.unwrap_or(0),
                 mem_reservation: composition.mem_reservation.unwrap_or(0),
-                // Compose ships fractional CPU; engine takes nanoseconds-of-CPU-per-second.
-                // Drop NaN/Inf/negative/overflow with a warning rather than producing a
-                // saturated i64 that the engine would silently accept.
+                // Compose ships fractional CPU; engine takes nano-CPUs. The
+                // value is validated at deserialization time, so a plain cast
+                // is safe here. Round to nearest to avoid drift on values like
+                // `0.3` whose binary f64 representation is slightly below the
+                // rational.
                 nano_cpus: composition
                     .cpus
-                    .and_then(|c| cpus_to_nano_cpus(id, c))
+                    .map(|c| (c * 1_000_000_000.0).round() as i64)
                     .unwrap_or(0),
                 oom_score_adj: composition.oom_score_adj,
                 pids_limit: composition.pids_limit,
@@ -328,34 +305,5 @@ impl<N> From<LocalContainer<N>> for Service {
             started,
             config,
         }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn cpus_to_nano_cpus_rounds_to_nearest() {
-        // 0.3 has no exact f64 representation; truncation would yield
-        // 299_999_999, rounding gives the user-intended 300_000_000.
-        assert_eq!(cpus_to_nano_cpus(1, 0.3), Some(300_000_000));
-        assert_eq!(cpus_to_nano_cpus(1, 1.5), Some(1_500_000_000));
-        assert_eq!(cpus_to_nano_cpus(1, 2.0), Some(2_000_000_000));
-        assert_eq!(cpus_to_nano_cpus(1, 0.0), Some(0));
-    }
-
-    #[test]
-    fn cpus_to_nano_cpus_rejects_invalid_values() {
-        assert_eq!(cpus_to_nano_cpus(1, f64::NAN), None);
-        assert_eq!(cpus_to_nano_cpus(1, f64::INFINITY), None);
-        assert_eq!(cpus_to_nano_cpus(1, f64::NEG_INFINITY), None);
-        assert_eq!(cpus_to_nano_cpus(1, -0.5), None);
-    }
-
-    #[test]
-    fn cpus_to_nano_cpus_rejects_overflow() {
-        // 1e10 cpus * 1e9 ns/cpu = 1e19, which exceeds i64::MAX (~9.2e18).
-        assert_eq!(cpus_to_nano_cpus(1, 1e10), None);
     }
 }

--- a/helios-state/src/tasks/app.rs
+++ b/helios-state/src/tasks/app.rs
@@ -855,9 +855,7 @@ fn start_service(
     // need to loop again to re-create the container
     enforce!(
         svc.config == tgt_svc.config,
-        "service configuration should match the target before start: {:?}, {:?}",
-        svc.config,
-        tgt_svc.config
+        "service configuration should match the target before start",
     );
 
     svc.started = true;
@@ -887,10 +885,8 @@ fn start_service(
             .await
             .context("failed to inspect container for service")?;
 
-        svc.oci.replace(Container::from((
-            local_container.name.as_ref(),
-            local_container.state,
-        )));
+        *svc = Service::from(local_container);
+        svc.image = tgt_svc.image;
 
         Ok(svc)
     })


### PR DESCRIPTION
Adds a few tweaks to field tracking to ensure compatibility with podman

- Makes sure to read the container configuration after start as some properties are set by the engine at that point
- Adds field tracking to some previously untracked fields, like `cgroup_private` and `uts` 
- Removes the `Option` on some engine fields that make sense if they default to 0
- Also moves validation of the `cpus` field to the entry point in helios-remote-model