### PR TITLE
Validate apps independenty

### DIFF
--- a/helios-integration-tests/src/api_tests.rs
+++ b/helios-integration-tests/src/api_tests.rs
@@ -4,9 +4,7 @@ use bollard::config::RestartPolicyNameEnum;
 use reqwest::StatusCode;
 use serde_json::{Value, json};
 
-use super::common::{
-    HELIOS_URL, clear_reports, prune_images, wait_for_report, wait_for_target_apply,
-};
+use super::common::{HELIOS_URL, prune_images, wait_for_target_apply};
 
 const TEST_APP_UUID: &str = "test-app";
 
@@ -243,7 +241,6 @@ async fn test_set_app_target() {
 #[tokio::test]
 async fn test_set_app_target_install_images() {
     prune_images().await;
-    clear_reports().await;
 
     let release_uuid = "my-release-uuid";
 
@@ -518,23 +515,7 @@ async fn test_set_app_target_install_images() {
     assert_eq!(tmpfs_opts.size_bytes, Some(65536));
     assert_eq!(tmpfs_opts.mode, Some(448));
 
-    // State report was sent with correct service statuses
-    let release_report = wait_for_report(TEST_APP_UUID, release_uuid, "done", 10).await;
-    assert_eq!(
-        release_report["services"]["service-one"]["status"],
-        "Running"
-    );
-    assert_eq!(
-        release_report["services"]["service-two"]["status"],
-        "Running"
-    );
-    assert_eq!(
-        release_report["services"]["service-three"]["status"],
-        "Running"
-    );
-
     // Teardown: remove app and confirm images are cleaned up
-    clear_reports().await;
     delete_app_and_wait(&client, TEST_APP_UUID).await;
     assert!(docker.inspect_image("ubuntu:latest").await.is_err());
     assert!(docker.inspect_image("alpine:latest").await.is_err());

--- a/helios-integration-tests/src/polling_tests.rs
+++ b/helios-integration-tests/src/polling_tests.rs
@@ -375,3 +375,183 @@ async fn test_hostos_update_retry_exhaustion() {
         .await
         .unwrap();
 }
+
+#[tokio::test]
+async fn test_rejected_app_is_reported() {
+    let client = reqwest::Client::new();
+
+    const APP_UUID: &str = "rejected-app-uuid";
+    const RELEASE_UUID: &str = "c8b48659434e80a8b3adc0c5ad1e347a";
+
+    // A release with a malformed service `command` (unclosed quote) fails
+    // per-release deserialization in helios-remote-model and lands as a
+    // rejection rather than aborting the whole target.
+    let mut releases = serde_json::Map::new();
+    releases.insert(
+        RELEASE_UUID.to_string(),
+        json!({
+            "id": 7,
+            "services": {
+                "main": {
+                    "id": 3,
+                    "image_id": 4,
+                    "image": "registry:5000/test-rejected:latest",
+                    "composition": {
+                        "command": "echo 'hello world",
+                    }
+                }
+            }
+        }),
+    );
+    let app_obj = json!({
+        "id": 400,
+        "name": "rejected-app",
+        "releases": serde_json::Value::Object(releases),
+    });
+    let mut apps = serde_json::Map::new();
+    apps.insert(APP_UUID.to_string(), app_obj);
+    let device_target = json!({
+        "name": "test-device",
+        "apps": serde_json::Value::Object(apps),
+    });
+
+    clear_reports().await;
+
+    let res = client
+        .put(format!("{MOCK_REMOTE_URL}/mock/state"))
+        .json(&device_target)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::OK);
+
+    let res = client
+        .post(format!("{HELIOS_URL}/v1/update"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::ACCEPTED);
+
+    // No hostapp in the target, so the overall apply aborts — same as the
+    // baseline user-app test. The rejection is reported independently.
+    let status = wait_for_target_apply().await;
+    assert_eq!(status, json!({"status": "aborted"}));
+
+    let release_report = wait_for_report(APP_UUID, RELEASE_UUID, "rejected", 10).await;
+    assert!(
+        release_report["services"]
+            .as_object()
+            .map(|m| m.is_empty())
+            .unwrap_or(false),
+        "rejected release should have no services, got: {release_report}"
+    );
+
+    let empty_target = json!({"name": "test-device", "apps": {}});
+    client
+        .put(format!("{MOCK_REMOTE_URL}/mock/state"))
+        .json(&empty_target)
+        .send()
+        .await
+        .unwrap();
+    let res = client
+        .post(format!("{HELIOS_URL}/v1/update"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::ACCEPTED);
+    wait_for_target_apply().await;
+
+    clear_reports().await;
+    client
+        .delete(format!("{MOCK_REMOTE_URL}/mock/state"))
+        .send()
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn test_remote_poll_user_app_reports_done() {
+    prune_images().await;
+
+    let client = reqwest::Client::new();
+
+    const APP_UUID: &str = "report-app-uuid";
+    const RELEASE_UUID: &str = "ddeeff00112233445566778899aabbcc";
+
+    let mut releases = serde_json::Map::new();
+    releases.insert(
+        RELEASE_UUID.to_string(),
+        json!({
+            "id": 8,
+            "services": {
+                "main": {
+                    "id": 401,
+                    "image_id": 402,
+                    "image": "alpine:latest",
+                    "composition": {
+                        "command": ["sleep", "infinity"],
+                    }
+                }
+            }
+        }),
+    );
+    let app_obj = json!({
+        "id": 500,
+        "name": "report-app",
+        "releases": serde_json::Value::Object(releases),
+    });
+    let mut apps = serde_json::Map::new();
+    apps.insert(APP_UUID.to_string(), app_obj);
+    let device_target = json!({
+        "name": "test-device",
+        "apps": serde_json::Value::Object(apps),
+    });
+
+    clear_reports().await;
+
+    let res = client
+        .put(format!("{MOCK_REMOTE_URL}/mock/state"))
+        .json(&device_target)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::OK);
+
+    let res = client
+        .post(format!("{HELIOS_URL}/v1/update"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::ACCEPTED);
+
+    // The remote target has no hostapp, so the overall apply converges
+    // to "aborted" (same pattern as the other polling tests). The user
+    // app still installs, and its per-release status reports as "done".
+    let status = wait_for_target_apply().await;
+    assert_eq!(status, json!({"status": "aborted"}));
+
+    let release_report = wait_for_report(APP_UUID, RELEASE_UUID, "done", 30).await;
+    assert_eq!(release_report["services"]["main"]["status"], "Running");
+
+    let empty_target = json!({"name": "test-device", "apps": {}});
+    client
+        .put(format!("{MOCK_REMOTE_URL}/mock/state"))
+        .json(&empty_target)
+        .send()
+        .await
+        .unwrap();
+    let res = client
+        .post(format!("{HELIOS_URL}/v1/update"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::ACCEPTED);
+    wait_for_target_apply().await;
+
+    clear_reports().await;
+    client
+        .delete(format!("{MOCK_REMOTE_URL}/mock/state"))
+        .send()
+        .await
+        .unwrap();
+}

--- a/helios-remote-model/src/labels.rs
+++ b/helios-remote-model/src/labels.rs
@@ -3,7 +3,7 @@ use std::ops::Deref;
 
 use serde::{Deserialize, Deserializer};
 
-#[derive(Clone, Debug, PartialEq, Eq, Default)]
+#[derive(Debug, PartialEq, Eq, Default)]
 pub struct Labels(HashMap<String, String>);
 
 impl Deref for Labels {

--- a/helios-remote-model/src/lib.rs
+++ b/helios-remote-model/src/lib.rs
@@ -25,7 +25,7 @@ use helios_util::types as common_types;
 use common_types::{ImageUri, Uuid};
 
 /// Target device as defined by the remote backend
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub struct Device {
     pub name: String,
     pub apps: AppMap,
@@ -53,7 +53,7 @@ impl<'de> Deserialize<'de> for Device {
     }
 }
 
-#[derive(Clone, Debug, Default)]
+#[derive(Debug, Default)]
 pub struct AppMap(HashMap<Uuid, App>);
 
 impl Deref for AppMap {
@@ -82,7 +82,7 @@ impl<'de> Deserialize<'de> for AppMap {
     where
         D: serde::Deserializer<'de>,
     {
-        #[derive(Deserialize, Clone, Debug)]
+        #[derive(Deserialize, Debug)]
         struct AppTarget {
             pub id: u32,
             pub name: String,
@@ -166,13 +166,13 @@ impl<'de> Deserialize<'de> for AppMap {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub enum App {
     User(UserApp),
     Host(HostApp),
 }
 
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub struct HostApp {
     pub release_uuid: Uuid,
     pub image: ImageUri,
@@ -181,7 +181,7 @@ pub struct HostApp {
 }
 
 /// Target app as defined by the remote backend
-#[derive(Deserialize, Clone, Debug)]
+#[derive(Deserialize, Debug)]
 pub struct UserApp {
     pub id: u32,
     pub name: String,
@@ -189,7 +189,7 @@ pub struct UserApp {
     pub releases: ReleaseMap,
 }
 
-#[derive(Clone, Debug, Default)]
+#[derive(Debug, Default)]
 pub struct ReleaseMap(HashMap<Uuid, Release>);
 
 impl Deref for ReleaseMap {
@@ -231,7 +231,7 @@ impl<'de> Deserialize<'de> for ReleaseMap {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub struct Release {
     pub services: HashMap<String, Service>,
     pub volumes: HashMap<String, Volume>,

--- a/helios-remote-model/src/lib.rs
+++ b/helios-remote-model/src/lib.rs
@@ -5,6 +5,7 @@
 //! the types are based  from https://github.com/balena-io/open-balena-api/blob/master/src/features/device-state/routes/state-get-v3.ts#L48
 
 use serde::Deserialize;
+use serde_json::Value;
 use std::{
     collections::HashMap,
     ops::{Deref, DerefMut},
@@ -77,88 +78,43 @@ impl IntoIterator for AppMap {
         self.0.into_iter()
     }
 }
+
 impl<'de> Deserialize<'de> for AppMap {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
-        #[derive(Deserialize, Debug)]
-        struct AppTarget {
-            pub id: u32,
-            pub name: String,
-            #[serde(default)]
-            pub is_host: bool,
-            #[serde(default)]
-            pub releases: ReleaseMap,
-        }
+        // Parse each app's JSON lazily so a per-app deserialization error
+        // (bad service composition, bad release map, missing hostapp labels)
+        // can be captured as a rejection rather than aborting the whole device.
+        let raw: HashMap<Uuid, Value> = HashMap::deserialize(deserializer)?;
 
-        let remote_apps: HashMap<Uuid, AppTarget> = HashMap::deserialize(deserializer)?;
-
-        // validate that there is only one hostapp
-        if remote_apps.iter().filter(|(_, app)| app.is_host).count() > 1 {
+        // Duplicate hostapps are a device-level configuration problem. Peek
+        // at the raw `is_host` flags before per-app parsing so the check
+        // still fires if the apps would otherwise fail validation.
+        if raw
+            .values()
+            .filter(|v| v.get("is_host").and_then(Value::as_bool).unwrap_or(false))
+            .count()
+            > 1
+        {
             return Err(serde::de::Error::custom(
                 "only one target hostapp is allowed",
             ));
         }
 
-        let mut apps = HashMap::new();
-        for (app_uuid, app) in remote_apps {
-            let AppTarget {
-                id,
-                name,
-                releases,
-                is_host,
-            } = app;
-            if !is_host {
-                apps.insert(app_uuid, App::User(UserApp { id, name, releases }));
-            // Only select the hostapp if it has the appropriate metadata
-            } else if let Some((release_uuid, release)) = releases.into_iter().next() {
-                let hostapp = release.services.into_values().find(|svc| {
-                    svc.composition
-                        .labels
-                        .get("io.balena.image.class")
-                        .map(|value| value == "hostapp")
-                        .is_some()
-                });
-
-                // The target OS may be before v6.1.18 where the hostapp and board-rev
-                // labels were added. If that's the case we won't be able to update to it so
-                // we remove it from the target state
-                if let Some(svc) = hostapp {
-                    // merge top level labels with those in the composition
-                    let mut labels: HashMap<String, String> = svc
-                        .composition
-                        .labels
-                        .into_iter()
-                        .chain(svc.labels)
-                        .collect();
-
-                    // The hostapp must provide an updater artifact
-                    let updater = if let Some(updater) = labels.remove("io.balena.private.updater")
-                    {
-                        updater.parse().map_err(serde::de::Error::custom)?
-                    } else {
-                        return Err(serde::de::Error::custom(
-                            "the hostapp must provide an updater artifact reference",
-                        ));
-                    };
-
-                    if let Some(board_rev) = labels.remove("io.balena.private.hostapp.board-rev") {
-                        apps.insert(
-                            app_uuid,
-                            App::Host(HostApp {
-                                release_uuid,
-                                image: svc.image,
-                                board_rev,
-                                updater,
-                            }),
-                        );
-                    }
+        let mut apps: HashMap<Uuid, App> = HashMap::new();
+        for (app_uuid, value) in raw {
+            match parse_app(value) {
+                Ok(app) => {
+                    apps.insert(app_uuid, app);
                 }
-            } else {
-                return Err(serde::de::Error::custom(
-                    "the hostapp must have at least one target release",
-                ));
+                Err(ParseAppError::Reject(rejection)) => {
+                    apps.insert(app_uuid, App::Rejected(rejection));
+                }
+                Err(ParseAppError::Fatal(msg)) => {
+                    return Err(serde::de::Error::custom(msg));
+                }
             }
         }
 
@@ -166,10 +122,157 @@ impl<'de> Deserialize<'de> for AppMap {
     }
 }
 
+/// An app with an invalid target release
+#[derive(Debug, Clone)]
+pub struct RejectedApp {
+    pub id: u32,
+    pub name: String,
+    pub is_host: bool,
+    pub release: Uuid,
+    pub reason: String,
+}
+
 #[derive(Debug)]
 pub enum App {
     User(UserApp),
     Host(HostApp),
+    Rejected(RejectedApp),
+}
+
+/// Outcome of `parse_app` — either an accepted `App`, a per-app rejection
+/// keyed by a specific release uuid, or a fatal device-level error that
+/// should abort the whole `AppMap` deserialization.
+enum ParseAppError {
+    Reject(RejectedApp),
+    Fatal(String),
+}
+
+fn parse_app(value: Value) -> Result<App, ParseAppError> {
+    #[derive(Deserialize, Debug)]
+    struct AppRaw {
+        id: u32,
+        name: String,
+        #[serde(default)]
+        is_host: bool,
+        #[serde(default)]
+        releases: HashMap<Uuid, Value>,
+    }
+
+    // Stage 1: parse the app's top-level shape, leaving releases as raw JSON.
+    // A failure here is an input error from the backend, not a per-release
+    // content problem — abort the whole device deserialization.
+    let app = AppRaw::deserialize(value).map_err(|e| ParseAppError::Fatal(e.to_string()))?;
+
+    // Stage 2: enforce the single-release constraint and parse each release
+    // independently so a per-release failure carries its uuid.
+    if app.releases.len() > 1 {
+        return Err(ParseAppError::Fatal(
+            "target releases should only contain one release".to_string(),
+        ));
+    }
+
+    let mut releases: HashMap<Uuid, Release> = HashMap::new();
+    for (rel_uuid, rel_value) in app.releases {
+        match serde_path_to_error::deserialize::<_, Release>(rel_value) {
+            Ok(rel) => {
+                releases.insert(rel_uuid, rel);
+            }
+            Err(e) => {
+                // Invalid release content, the app is rejected
+                return Err(ParseAppError::Reject(RejectedApp {
+                    id: app.id,
+                    name: app.name,
+                    is_host: app.is_host,
+                    release: rel_uuid,
+                    reason: e.to_string(),
+                }));
+            }
+        }
+    }
+    let releases = ReleaseMap(releases);
+
+    if !app.is_host {
+        return Ok(App::User(UserApp {
+            id: app.id,
+            name: app.name,
+            releases,
+        }));
+    }
+
+    // Stage 3: hostapp metadata validation. An empty release map at this
+    // point is a shape problem (the backend sent a hostapp with no release).
+    // Everything else is content of a specific release and
+    // produces a per-app rejection tagged with that release's uuid.
+    let Some((release_uuid, release)) = releases.into_iter().next() else {
+        return Err(ParseAppError::Fatal(
+            "hostapp should have at least one target release".to_string(),
+        ));
+    };
+
+    let Some(svc) = release.services.into_values().find(|svc| {
+        svc.composition
+            .labels
+            .get("io.balena.image.class")
+            .map(|value| value == "hostapp")
+            .is_some()
+    }) else {
+        return Err(ParseAppError::Reject(RejectedApp {
+            id: app.id,
+            name: app.name,
+            is_host: app.is_host,
+            release: release_uuid,
+            reason: "hostapp should have a service with `io.balena.image.class=hostapp` label"
+                .to_string(),
+        }));
+    };
+
+    let mut labels: HashMap<String, String> = svc
+        .composition
+        .labels
+        .into_iter()
+        .chain(svc.labels)
+        .collect();
+
+    let updater = match labels.remove("io.balena.private.updater") {
+        Some(updater) => match updater.parse::<ImageUri>() {
+            Ok(u) => u,
+            Err(e) => {
+                return Err(ParseAppError::Reject(RejectedApp {
+                    id: app.id,
+                    name: app.name,
+                    is_host: app.is_host,
+                    release: release_uuid,
+                    reason: format!("invalid hostapp updater: {e}"),
+                }));
+            }
+        },
+        None => {
+            return Err(ParseAppError::Reject(RejectedApp {
+                id: app.id,
+                name: app.name,
+                is_host: app.is_host,
+                release: release_uuid,
+                reason: "hostapp missing `updater` label".to_string(),
+            }));
+        }
+    };
+
+    let Some(board_rev) = labels.remove("io.balena.private.hostapp.board-rev") else {
+        return Err(ParseAppError::Reject(RejectedApp {
+            id: app.id,
+            name: app.name,
+            is_host: app.is_host,
+            release: release_uuid,
+            reason: "hostapp missing `board_rev` label".to_string(),
+        }));
+    };
+
+    Ok(App::Host(HostApp {
+        release_uuid,
+        image: svc.image,
+        board_rev,
+        updater,
+    }))
 }
 
 #[derive(Debug)]
@@ -376,11 +479,10 @@ mod tests {
 
         });
 
-        let apps = serde_json::from_value::<AppMap>(json);
-        assert!(
-            apps.is_err_and(
-                |e| e.to_string() == "the hostapp must have at least one target release"
-            )
+        let err = serde_json::from_value::<AppMap>(json).unwrap_err();
+        assert_eq!(
+            err.to_string(),
+            "hostapp should have at least one target release",
         );
     }
 
@@ -412,11 +514,19 @@ mod tests {
 
         });
 
-        let err = serde_json::from_value::<Device>(json).unwrap_err();
+        let device: Device = serde_json::from_value(json).unwrap();
+        let rejection = match device.apps.get(&Uuid::from("app-one")) {
+            Some(App::Rejected(r)) => r,
+            other => panic!("app-one should be rejected, got {other:?}"),
+        };
         assert_eq!(
-            err.to_string(),
-            "apps.?.releases.?.services.main.composition.command: missing closing quote"
-        )
+            rejection.release,
+            Uuid::from("c8b48659434e80a8b3adc0c5ad1e347a"),
+        );
+        assert_eq!(
+            rejection.reason,
+            "services.main.composition.command: missing closing quote",
+        );
     }
 
     #[test]
@@ -455,11 +565,19 @@ mod tests {
 
         });
 
-        let err = serde_json::from_value::<Device>(json).unwrap_err();
+        let device: Device = serde_json::from_value(json).unwrap();
+        let rejection = match device.apps.get(&Uuid::from("app-one")) {
+            Some(App::Rejected(r)) => r,
+            other => panic!("app-one should be rejected, got {other:?}"),
+        };
         assert_eq!(
-            err.to_string(),
-            "apps.?.releases.?.services.main.composition.networks.my-net.aliases: invalid type: string \"my-alias\", expected a sequence"
-        )
+            rejection.release,
+            Uuid::from("c8b48659434e80a8b3adc0c5ad1e347a"),
+        );
+        assert_eq!(
+            rejection.reason,
+            "services.main.composition.networks.my-net.aliases: invalid type: string \"my-alias\", expected a sequence",
+        );
     }
 
     #[test]
@@ -499,11 +617,19 @@ mod tests {
             }
         });
 
-        let err = serde_json::from_value::<Device>(json).unwrap_err();
+        let device: Device = serde_json::from_value(json).unwrap();
+        let rejection = match device.apps.get(&Uuid::from("app-one")) {
+            Some(App::Rejected(r)) => r,
+            other => panic!("app-one should be rejected, got {other:?}"),
+        };
         assert_eq!(
-            err.to_string(),
-            "apps.?.releases.?.services.main.composition.volumes[0].read_only: invalid type: string \"yes\", expected a boolean"
-        )
+            rejection.release,
+            Uuid::from("c8b48659434e80a8b3adc0c5ad1e347a"),
+        );
+        assert_eq!(
+            rejection.reason,
+            "services.main.composition.volumes[0].read_only: invalid type: string \"yes\", expected a boolean",
+        );
     }
 
     #[test]
@@ -536,11 +662,19 @@ mod tests {
 
         });
 
-        let err = serde_json::from_value::<Device>(json).unwrap_err();
+        let device: Device = serde_json::from_value(json).unwrap();
+        let rejection = match device.apps.get(&Uuid::from("app-one")) {
+            Some(App::Rejected(r)) => r,
+            other => panic!("app-one should be rejected, got {other:?}"),
+        };
         assert_eq!(
-            err.to_string(),
-            "apps.?.releases.?.services.main.composition.environment.MY_VAR: invalid type: sequence, expected a boolean, number, or string"
-        )
+            rejection.release,
+            Uuid::from("c8b48659434e80a8b3adc0c5ad1e347a"),
+        );
+        assert_eq!(
+            rejection.reason,
+            "services.main.composition.environment.MY_VAR: invalid type: sequence, expected a boolean, number, or string",
+        );
     }
 
     #[test]
@@ -573,11 +707,80 @@ mod tests {
 
         });
 
-        let err = serde_json::from_value::<Device>(json).unwrap_err();
+        let device: Device = serde_json::from_value(json).unwrap();
+        let rejection = match device.apps.get(&Uuid::from("app-one")) {
+            Some(App::Rejected(r)) => r,
+            other => panic!("app-one should be rejected, got {other:?}"),
+        };
         assert_eq!(
-            err.to_string(),
-            "apps.?.releases.?.services.main.composition.labels.my-label: invalid type: integer `123`, expected a string"
-        )
+            rejection.release,
+            Uuid::from("c8b48659434e80a8b3adc0c5ad1e347a"),
+        );
+        assert_eq!(
+            rejection.reason,
+            "services.main.composition.labels.my-label: invalid type: integer `123`, expected a string",
+        );
+    }
+
+    #[test]
+    fn test_rejects_only_invalid_app_keeping_valid_ones() {
+        let json = json!({
+            "name": "my-device",
+            "apps": {
+                "good-app": {
+                    "id": 1,
+                    "name": "good",
+                    "releases": {
+                        "rel-good": {
+                            "id": 10,
+                            "services": {
+                                "main": {
+                                    "id": 100,
+                                    "image_id": 200,
+                                    "image": "registry2.balena-cloud.com/v2/8a961e0325a37441f33091743fa40a4c@sha256:0f3169ee8672222eb775b032cb3b2d06ef8eafa23a970643052bb67ac1fc5cd9",
+                                }
+                            }
+                        }
+                    }
+                },
+                "bad-app": {
+                    "id": 2,
+                    "name": "bad",
+                    "releases": {
+                        "rel-bad": {
+                            "id": 11,
+                            "services": {
+                                "main": {
+                                    "id": 101,
+                                    "image_id": 201,
+                                    "image": "registry2.balena-cloud.com/v2/8a961e0325a37441f33091743fa40a4c@sha256:0f3169ee8672222eb775b032cb3b2d06ef8eafa23a970643052bb67ac1fc5cd9",
+                                    "composition": {
+                                        "command": "echo 'unterminated"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        });
+
+        let device: Device = serde_json::from_value(json).unwrap();
+        assert_eq!(device.apps.len(), 2);
+        assert!(matches!(
+            device.apps.get(&Uuid::from("good-app")),
+            Some(App::User(_)),
+        ));
+        let rejection = match device.apps.get(&Uuid::from("bad-app")) {
+            Some(App::Rejected(r)) => r,
+            other => panic!("bad-app should be rejected, got {other:?}"),
+        };
+        assert_eq!(rejection.release, Uuid::from("rel-bad"));
+        assert!(
+            rejection.reason.contains("missing closing quote"),
+            "unexpected reason: {}",
+            rejection.reason,
+        );
     }
 
     #[test]

--- a/helios-remote-model/src/network.rs
+++ b/helios-remote-model/src/network.rs
@@ -4,7 +4,7 @@ use std::collections::HashMap;
 use super::labels::Labels;
 
 /// Target network as defined by the remote backend
-#[derive(Deserialize, Clone, Debug, Default)]
+#[derive(Deserialize, Debug, Default)]
 pub struct Network {
     #[serde(default)]
     pub driver: Option<String>,
@@ -20,7 +20,7 @@ pub struct Network {
     pub ipam: Option<NetworkIpam>,
 }
 
-#[derive(Deserialize, Clone, Debug)]
+#[derive(Deserialize, Debug)]
 pub struct NetworkIpam {
     #[serde(default)]
     pub driver: Option<String>,
@@ -30,7 +30,7 @@ pub struct NetworkIpam {
     pub options: HashMap<String, String>,
 }
 
-#[derive(Deserialize, Clone, Debug)]
+#[derive(Deserialize, Debug)]
 pub struct IpamConfig {
     pub subnet: Option<String>,
     pub gateway: Option<String>,

--- a/helios-remote-model/src/service/cgroup.rs
+++ b/helios-remote-model/src/service/cgroup.rs
@@ -3,7 +3,7 @@ use serde::Deserialize;
 /// Service `cgroup` namespace mode as defined by the Compose spec.
 ///
 /// Compose accepts `host` or `private`
-#[derive(Clone, Debug, PartialEq, Eq, Deserialize)]
+#[derive(Debug, PartialEq, Eq, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum Cgroup {
     Host,

--- a/helios-remote-model/src/service/command.rs
+++ b/helios-remote-model/src/service/command.rs
@@ -2,7 +2,7 @@ use serde::Deserialize;
 use serde::de::{self, Deserializer};
 use std::ops::Deref;
 
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub struct Command(Vec<String>);
 
 impl Deref for Command {

--- a/helios-remote-model/src/service/mod.rs
+++ b/helios-remote-model/src/service/mod.rs
@@ -23,7 +23,7 @@ pub use volumes::*;
 use super::labels::Labels;
 
 /// Target service as defined by the remote backend
-#[derive(Deserialize, Clone, Debug)]
+#[derive(Deserialize, Debug)]
 pub struct Service {
     pub id: u32,
     pub image: ImageUri,
@@ -39,7 +39,7 @@ pub struct Service {
 }
 
 // FIXME: add remaining fields
-#[derive(Deserialize, Clone, Debug, Default)]
+#[derive(Deserialize, Debug, Default)]
 pub struct ServiceComposition {
     #[serde(default)]
     pub cgroup: Option<Cgroup>,

--- a/helios-remote-model/src/service/network_mode.rs
+++ b/helios-remote-model/src/service/network_mode.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Deserializer};
 /// supported. Other platform specific modes are not supported as they might break.
 /// The `service:{name}` mode will be supported once `depends_on` is implemented, and
 /// `container:{name}` is not supported — both are rejected on deserialization.
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum NetworkMode {
     None,
     Host,

--- a/helios-remote-model/src/service/networks.rs
+++ b/helios-remote-model/src/service/networks.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Deserializer};
 
 /// Per-network endpoint configuration for a service (without priority, which is consumed during
 /// deserialization to determine insertion order)
-#[derive(Deserialize, Clone, Debug, Default, PartialEq, Eq)]
+#[derive(Deserialize, Debug, Default, PartialEq, Eq)]
 #[serde(default)]
 pub struct NetworkSettings {
     #[serde(default)]
@@ -78,7 +78,7 @@ impl NetworkSettingsWithPriority {
 /// `None` means "connect with default settings". Entries are ordered by descending `priority`
 /// (highest priority first), which determines the order in which the container connects to
 /// networks.
-#[derive(Clone, Debug, Default, PartialEq, Eq)]
+#[derive(Debug, Default, PartialEq, Eq)]
 pub struct NetworkingConfig(IndexMap<String, Option<NetworkSettings>>);
 
 impl Deref for NetworkingConfig {

--- a/helios-remote-model/src/service/restart_policy.rs
+++ b/helios-remote-model/src/service/restart_policy.rs
@@ -4,7 +4,7 @@ use serde::de;
 /// Docker compose restart policy.
 ///
 /// Supports `no`, `always`, `on-failure[:max-retries]`, and `unless-stopped`.
-#[derive(Clone, Debug, PartialEq, Eq, Default)]
+#[derive(Debug, PartialEq, Eq, Default)]
 pub enum RestartPolicy {
     No,
     #[default]

--- a/helios-remote-model/src/service/volumes.rs
+++ b/helios-remote-model/src/service/volumes.rs
@@ -14,7 +14,7 @@ use serde::{
 use std::fmt;
 
 /// Bind mount propagation mode.
-#[derive(Deserialize, Clone, Debug, Copy, PartialEq, Eq)]
+#[derive(Deserialize, Clone, Copy, Debug, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum BindPropagation {
     Private,
@@ -26,7 +26,7 @@ pub enum BindPropagation {
 }
 
 /// Volume-type mount (references a named volume declared in the top-level `volumes`).
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct VolumeMount {
     pub source: String,
     pub target: String,
@@ -36,7 +36,7 @@ pub struct VolumeMount {
 }
 
 /// Bind-type mount (maps a host path into the container).
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct BindMount {
     pub source: String,
     pub target: String,
@@ -47,7 +47,7 @@ pub struct BindMount {
 }
 
 /// Tmpfs-type mount (in-memory filesystem).
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct TmpfsMount {
     pub target: String,
     pub size: Option<i64>,
@@ -55,7 +55,7 @@ pub struct TmpfsMount {
 }
 
 /// A single service mount entry.
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum Mount {
     Volume(VolumeMount),
     Bind(BindMount),
@@ -92,7 +92,7 @@ fn is_allowed_bind_source(source: &str) -> bool {
 }
 
 /// Service mount list.
-#[derive(Clone, Debug, Default, PartialEq, Eq)]
+#[derive(Debug, Default, PartialEq, Eq)]
 pub struct VolumesConfig(Vec<Mount>);
 
 impl VolumesConfig {

--- a/helios-remote-model/src/volume.rs
+++ b/helios-remote-model/src/volume.rs
@@ -4,7 +4,7 @@ use std::collections::HashMap;
 use super::labels::Labels;
 
 /// Target volume as defined by the remote backend
-#[derive(Deserialize, Clone, Debug)]
+#[derive(Deserialize, Debug)]
 pub struct Volume {
     #[serde(default)]
     pub driver: Option<String>,

--- a/helios-remote/src/poll.rs
+++ b/helios-remote/src/poll.rs
@@ -13,7 +13,7 @@ use crate::util::request::{self, Get};
 use crate::util::types::Uuid;
 
 use super::config::{RemoteConfig, RequestConfig};
-use super::model::Device as RemoteDeviceTarget;
+use super::model::{App as RemoteApp, Device as RemoteDeviceTarget};
 
 async fn get_poll_client(uuid: &Uuid, remote: &RemoteConfig) -> (Get, Option<Value>) {
     let uri = remote.api_endpoint.clone();
@@ -244,6 +244,17 @@ async fn start_poll_with_reemit(
                     match serde_json::from_value::<RemoteTargetState>(target_state.clone()) {
                         Ok(RemoteTargetState(mut map)) => {
                             if let Some(remote_target) = map.remove(&uuid) {
+                                // Log per-app rejections; the rejected entries flow
+                                // through into the DeviceTarget so the planner can
+                                // create the app with `rejected_release` set.
+                                for (uuid, app) in remote_target.apps.iter() {
+                                    if let RemoteApp::Rejected(rej) = app {
+                                        warn!(
+                                            "invalid target release for app {uuid}: {}",
+                                            rej.reason,
+                                        );
+                                    }
+                                }
                                 let _ = seek_tx.send(SeekRequest {
                                     target: TargetState::Remote {
                                         target: Some(remote_target.into()),

--- a/helios-remote/src/poll.rs
+++ b/helios-remote/src/poll.rs
@@ -69,7 +69,7 @@ async fn poll_remote(
     (value, req.opts, Instant::now() + next_poll(config))
 }
 
-#[derive(Deserialize, Clone, Debug)]
+#[derive(Deserialize, Debug)]
 struct RemoteTargetState(HashMap<Uuid, RemoteDeviceTarget>);
 
 /// An update request coming from the API.

--- a/helios-remote/src/report.rs
+++ b/helios-remote/src/report.rs
@@ -1,4 +1,4 @@
-use helios_state::models::{Device, ImageRef};
+use helios_state::models::{App, Device, ImageRef};
 use serde::Serialize;
 use serde_json::Value;
 use std::collections::HashMap;
@@ -30,7 +30,7 @@ enum ServiceStatus {
 #[derive(Clone, Serialize, Debug, PartialEq, Eq, PartialOrd, Ord)]
 #[serde(rename_all = "lowercase")]
 pub enum UpdateStatus {
-    // Rejected,
+    Rejected,
     Aborted,
     Downloading,
     Downloaded,
@@ -188,8 +188,13 @@ impl From<LocalState> for DeviceReport {
                 continue;
             }
 
-            let release_is_unique = app.releases.len() == 1;
-            for (rel_uuid, rel) in app.releases {
+            let App {
+                releases,
+                rejected_release,
+                ..
+            } = app;
+            let release_is_unique = releases.len() == 1;
+            for (rel_uuid, rel) in releases {
                 for (svc_name, svc) in rel.services {
                     let svc_img = if let ImageRef::Uri(img) = svc.image {
                         img
@@ -267,6 +272,22 @@ impl From<LocalState> for DeviceReport {
                         },
                     );
                 }
+            }
+
+            // If the app contains a `rejected_release` property, add the release with
+            // `update_status: "rejected"`. This is independent of any still running releases.
+            if let Some(rejected) = rejected_release {
+                let report = apps.entry(app_uuid).or_insert(AppReport {
+                    release_uuid: None,
+                    releases: HashMap::new(),
+                });
+                report.releases.insert(
+                    rejected,
+                    ReleaseReport {
+                        update_status: UpdateStatus::Rejected,
+                        services: HashMap::new(),
+                    },
+                );
             }
         }
 
@@ -591,6 +612,142 @@ mod tests {
 
         assert!(apps.contains_key(&Uuid::from("my-app")));
         assert!(!apps.contains_key(&Uuid::from("other-app")));
+    }
+
+    #[test]
+    fn it_reports_rejected_release_alongside_current() {
+        // A rejected app whose current release is still running. The report
+        // should keep the current release entry (with its real status) and
+        // add a rejected release entry next to it.
+        let device = serde_json::from_value::<Device>(json!({
+            "uuid": "device-123",
+            "images": {
+                "img-a": {
+                    "oci_id": "sha256:abc",
+                    "download_progress": 100,
+                }
+            },
+            "apps": {
+                "rejected-app": {
+                    "id": 1,
+                    "rejected_release": "bad-release",
+                    "releases": {
+                        "current-release": {
+                            "installed": true,
+                            "services": {
+                                "svc-a": {
+                                    "id": 1,
+                                    "image": "img-a",
+                                    "oci": {
+                                        "name": "current-release_svc-a",
+                                        "status": "running",
+                                        "created": "2026-02-01T20:39:15+00:00"
+                                    },
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }))
+        .unwrap();
+
+        let report = Report::from(LocalState {
+            authorized_apps: vec![Uuid::from("rejected-app")],
+            status: crate::state::UpdateStatus::Done,
+            device,
+        });
+
+        let app = report
+            .0
+            .get("device-123")
+            .and_then(|d| d.apps.as_ref())
+            .and_then(|apps| apps.get(&Uuid::from("rejected-app")))
+            .expect("rejected app should be in the report");
+
+        // Current release still reported with its actual status.
+        assert_eq!(app.release_uuid, Some(Uuid::from("current-release")));
+        let current = app
+            .releases
+            .get(&Uuid::from("current-release"))
+            .expect("current release entry should be preserved");
+        assert_eq!(current.update_status, UpdateStatus::Done);
+        assert!(current.services.contains_key("svc-a"));
+
+        // Rejected release reported alongside.
+        let rejected = app
+            .releases
+            .get(&Uuid::from("bad-release"))
+            .expect("rejected release entry should be emitted");
+        assert_eq!(rejected.update_status, UpdateStatus::Rejected);
+        assert!(rejected.services.is_empty());
+    }
+
+    #[test]
+    fn it_reports_never_installed_rejected_app() {
+        // A rejected app with no current release: emit an app entry with
+        // a single rejected release.
+        let device = serde_json::from_value::<Device>(json!({
+            "uuid": "device-123",
+            "images": {},
+            "apps": {
+                "never-installed": {
+                    "id": 1,
+                    "rejected_release": "bad-release",
+                    "releases": {}
+                }
+            }
+        }))
+        .unwrap();
+
+        let report = Report::from(LocalState {
+            authorized_apps: vec![Uuid::from("never-installed")],
+            status: crate::state::UpdateStatus::Done,
+            device,
+        });
+
+        let app = report
+            .0
+            .get("device-123")
+            .and_then(|d| d.apps.as_ref())
+            .and_then(|apps| apps.get(&Uuid::from("never-installed")))
+            .expect("rejected app should be in the report");
+        assert_eq!(app.release_uuid, None);
+        assert_eq!(app.releases.len(), 1);
+        let release = app
+            .releases
+            .get(&Uuid::from("bad-release"))
+            .expect("rejected release should be present");
+        assert_eq!(release.update_status, UpdateStatus::Rejected);
+    }
+
+    #[test]
+    fn it_skips_unauthorized_rejected_apps() {
+        let device = serde_json::from_value::<Device>(json!({
+            "uuid": "device-123",
+            "images": {},
+            "apps": {
+                "unauthorized-app": {
+                    "id": 1,
+                    "rejected_release": "rel",
+                    "releases": {}
+                }
+            }
+        }))
+        .unwrap();
+
+        let report = Report::from(LocalState {
+            authorized_apps: Vec::new(),
+            status: crate::state::UpdateStatus::Done,
+            device,
+        });
+
+        let apps = report
+            .0
+            .get("device-123")
+            .and_then(|d| d.apps.as_ref())
+            .expect("apps should be present");
+        assert!(apps.is_empty());
     }
 
     #[test]

--- a/helios-state/src/models/app.rs
+++ b/helios-state/src/models/app.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 use mahler::state::{Map, State};
 
 use crate::common_types::Uuid;
-use crate::remote_model::UserApp as RemoteAppTarget;
+use crate::remote_model::{RejectedApp, UserApp as RemoteAppTarget};
 
 use super::release::Release;
 
@@ -28,6 +28,10 @@ pub struct App {
 
     /// App releases
     pub releases: Map<Uuid, Release>,
+
+    /// A rejected release uuid on the target state. This tells
+    /// the planner to abort operations the current app
+    pub rejected_release: Option<Uuid>,
 }
 
 impl From<App> for AppTarget {
@@ -43,6 +47,7 @@ impl From<App> for AppTarget {
             id,
             name,
             locked,
+            rejected_release: None,
             releases: releases
                 .into_iter()
                 .map(|(uuid, rel)| (uuid, rel.into()))
@@ -53,6 +58,22 @@ impl From<App> for AppTarget {
 
 pub type AppMap = Map<Uuid, App>;
 
+impl From<RejectedApp> for AppTarget {
+    fn from(app: RejectedApp) -> Self {
+        let RejectedApp {
+            id, name, release, ..
+        } = app;
+
+        AppTarget {
+            id,
+            name: Some(name),
+            locked: false,
+            releases: Map::new(),
+            rejected_release: Some(release),
+        }
+    }
+}
+
 impl From<RemoteAppTarget> for AppTarget {
     fn from(tgt: RemoteAppTarget) -> Self {
         let RemoteAppTarget { id, name, releases } = tgt;
@@ -61,6 +82,7 @@ impl From<RemoteAppTarget> for AppTarget {
             id,
             name: Some(name),
             locked: false,
+            rejected_release: None,
             releases: releases
                 .into_iter()
                 .map(|(r_uuid, rel)| (r_uuid, rel.into()))

--- a/helios-state/src/models/device.rs
+++ b/helios-state/src/models/device.rs
@@ -172,6 +172,11 @@ impl From<RemoteDeviceTarget> for DeviceTarget {
                 }
                 #[cfg(not(feature = "userapps"))]
                 RemoteAppTarget::User(_) => {}
+                #[cfg(feature = "userapps")]
+                RemoteAppTarget::Rejected(app) if !app.is_host => {
+                    userapps.insert(app_uuid, app.into());
+                }
+                _ => {}
             };
         }
 
@@ -222,5 +227,80 @@ mod tests {
         // this should not panic
         let _target: DeviceTarget =
             serde_json::from_value(serde_json::to_value(device).unwrap()).unwrap();
+    }
+
+    #[cfg(feature = "userapps")]
+    #[test]
+    fn rejected_user_app_is_included_in_target_with_rejected_release_set() {
+        // A rejected user app should land in `target.apps` with empty
+        // releases and the rejected release uuid set, so the planner can
+        // create the app locally and the report layer can surface it.
+        let remote: crate::remote_model::Device = serde_json::from_value(json!({
+            "name": "test-device",
+            "apps": {
+                "bad-app": {
+                    "id": 7,
+                    "name": "bad",
+                    "releases": {
+                        "bad-release": {
+                            "id": 1,
+                            "services": {
+                                "main": {
+                                    "id": 1,
+                                    "image_id": 1,
+                                    "image": "registry/img:1",
+                                    "composition": {
+                                        "command": "echo 'unterminated"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }))
+        .unwrap();
+
+        let target: DeviceTarget = remote.into();
+        let app = target
+            .apps
+            .get(&Uuid::from("bad-app"))
+            .expect("rejected user app should be in the target");
+        assert!(app.releases.is_empty());
+        assert_eq!(app.rejected_release, Some(Uuid::from("bad-release")));
+    }
+
+    #[cfg(all(feature = "userapps", feature = "balenahup"))]
+    #[test]
+    fn rejected_host_app_is_dropped_from_target() {
+        // Rejected host apps are filtered out — the device keeps running
+        // its current host release and there is nothing to report against.
+        let remote: crate::remote_model::Device = serde_json::from_value(json!({
+            "name": "test-device",
+            "apps": {
+                "bad-host": {
+                    "id": 8,
+                    "name": "host",
+                    "is_host": true,
+                    "releases": {
+                        "bad-release": {
+                            "id": 2,
+                            "services": {
+                                "hostapp": {
+                                    "id": 1,
+                                    "image_id": 1,
+                                    "image": "registry/img:1",
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }))
+        .unwrap();
+
+        let target: DeviceTarget = remote.into();
+        assert!(target.apps.is_empty());
+        assert!(target.host.is_none());
     }
 }

--- a/helios-state/src/read.rs
+++ b/helios-state/src/read.rs
@@ -57,6 +57,7 @@ async fn get_or_create_app<'a>(
                 locked: false,
                 lockfiles: Vec::new(),
                 releases: Map::new(),
+                rejected_release: None,
             },
         );
     }
@@ -113,6 +114,7 @@ pub async fn read(
                         locked: false,
                         lockfiles: Vec::new(),
                         releases: Map::new(),
+                        rejected_release: None,
                     },
                 );
             }

--- a/helios-state/src/seek.rs
+++ b/helios-state/src/seek.rs
@@ -209,6 +209,10 @@ fn report_state(tx: &Sender<LocalState>, device: &Device, status: &UpdateStatus)
     }
 }
 
+/// Refresh the authorization list in the shared local state.
+///
+/// Should only be used for remote targets, local targets (via the helios API) cannot modify the
+/// authorization list
 fn report_authorized_apps(tx: &Sender<LocalState>, target_state: &DeviceTarget) {
     // FIXME: re-enable reporting once user app support is more advanced.
     // At that point helios should be the only one reporting
@@ -225,7 +229,7 @@ fn report_authorized_apps(tx: &Sender<LocalState>, target_state: &DeviceTarget) 
             #[cfg(not(feature = "balenahup"))]
             let host_keys: Vec<&Uuid> = Vec::new();
 
-            state.authorized_apps = app_keys.chain(host_keys).cloned().collect()
+            state.authorized_apps = app_keys.chain(host_keys).cloned().collect();
         });
     }
 }
@@ -432,8 +436,13 @@ pub async fn start_seek(
             }
 
             SeekAction::Apply(update_req) => {
-                // Update authorization list
-                if let Some(target) = &update_req.target.value() {
+                // Refresh authorization list from the remote target.
+                // Local targets don't carry this info.
+                if let TargetState::Remote {
+                    target: Some(target),
+                    ..
+                } = &update_req.target
+                {
                     report_authorized_apps(&state_tx, target);
                 }
 

--- a/helios-state/src/tasks/app.rs
+++ b/helios-state/src/tasks/app.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 use std::io;
 use std::path::{Path, PathBuf};
 
+use mahler::exception;
 use mahler::extract::{Args, RawTarget, Res, System, SystemTarget, Target, View};
 use mahler::job;
 use mahler::state::Map;
@@ -47,13 +48,19 @@ fn create_app(
 ) -> IO<App, store::Error> {
     enforce!(maybe_app.is_none(), "app already exists");
 
-    let AppTarget { id, name, .. } = tgt_app;
+    let AppTarget {
+        id,
+        name,
+        rejected_release,
+        ..
+    } = tgt_app;
     let app = maybe_app.create(App {
         id,
         name,
         locked: false,
         lockfiles: Vec::new(),
         releases: Map::new(),
+        rejected_release,
     });
 
     with_io(app, async move |app| {
@@ -80,6 +87,19 @@ fn remove_app(mut app: View<Option<App>>) -> View<Option<App>> {
         app.take();
     }
     app
+}
+
+/// Set or clear the app's rejected release flag.
+///
+/// The field is in-memory only — it tracks the target's rejection state
+/// so the planner can preserve the current release via an exception and
+/// so the report layer can surface the rejected release uuid.
+fn set_rejected_release(
+    mut current: View<Option<Uuid>>,
+    Target(target): Target<Option<Uuid>>,
+) -> View<Option<Uuid>> {
+    *current = target;
+    current
 }
 
 /// Update the local app id
@@ -1251,6 +1271,17 @@ pub fn with_userapp_tasks<O>(worker: Worker<O, Uninitialized>) -> Worker<O, Unin
             }),
         )
         .jobs(
+            "/apps/{app_uuid}/rejected_release",
+            [job::any(set_rejected_release).with_description(
+                |Args(uuid): Args<Uuid>, Target(commit): Target<Option<Uuid>>| {
+                    format!(
+                        "set rejected target release for app '{uuid}' to {}",
+                        commit.as_ref().map(|c| c.as_str()).unwrap_or("none")
+                    )
+                },
+            )],
+        )
+        .jobs(
             "/apps/{app_uuid}/releases/{commit}",
             [
                 job::create(create_release).with_description(
@@ -1382,5 +1413,19 @@ pub fn with_userapp_tasks<O>(worker: Worker<O, Uninitialized>) -> Worker<O, Unin
                     )
                 },
             ),
+        )
+        .exception(
+            "/apps/{app_uuid}/releases/{commit}",
+            exception::delete(
+                |SystemTarget(device): SystemTarget<Device>,
+                 Args((app_uuid, _)): Args<(Uuid, Uuid)>| {
+                    device
+                        .apps
+                        .get(&app_uuid)
+                        .and_then(|t_app| t_app.rejected_release.as_ref())
+                        .is_some()
+                },
+            )
+            .with_description(|| "app has an invalid target release"),
         )
 }


### PR DESCRIPTION
When processing the target state, apps are now deserialized/validated independently, returning a `RejectedApp` with a validation reason to the state engine. This prevents rejecting the whole target state when a single app fails to be processed.

A rejected release is now reported back to the remote API using the `update_status` property

This PR should fix #93