### PR TITLE
Enable run_task log messages

### DIFF
--- a/helios/src/main.rs
+++ b/helios/src/main.rs
@@ -43,6 +43,7 @@ fn initialize_tracing() {
             EnvFilter::try_from_default_env().unwrap_or(
                 EnvFilter::default()
                     .add_directive("warn".parse().unwrap())
+                    .add_directive("mahler=info".parse().unwrap())
                     .add_directive("helios=info".parse().unwrap()),
             ),
         )


### PR DESCRIPTION
PR #115 disabled `helios::seek::run_task` messages (see below). This re-enables them as these provide valuable information of the workflow runtime state.

```
INFO helios:seek:run_task: starting task=start service 'data' for release '15c68e79b34d6e470a994012b217a25070ddd5e5'
INFO helios:seek:run_task: starting task=start service 'frontend' for release '15c68e79b34d6e470a994012b217a25070ddd5e5'
INFO helios:seek:run_task: starting task=start service 'proxy' for release '15c68e79b34d6e470a994012b217a25070ddd5e5'
INFO helios:seek:run_task: close time.busy=1.91ms time.idle=66.9ms task=start service 'data' for release '15c68e79b34d6e470a994012b217a25070ddd5e5'
INFO helios:seek:run_task: close time.busy=1.47ms time.idle=84.4ms task=start service 'proxy' for release '15c68e79b34d6e470a994012b217a25070ddd5e5'
INFO helios:seek:run_task: close time.busy=1.31ms time.idle=85.6ms task=start service 'frontend' for release '15c68e79b34d6e470a994012b217a25070ddd5e5'
```

Change-type: patch