### PR TITLE
Allow to force acquire locks

### DIFF
--- a/helios-state/src/seek.rs
+++ b/helios-state/src/seek.rs
@@ -15,6 +15,7 @@ use tracing::{error, info, instrument, trace, warn};
 use crate::common_types::Uuid;
 use crate::legacy::{self, LegacyConfig, ProxyState, StateUpdateError};
 use crate::util::interrupt::Interrupt;
+use crate::util::locking::ForceAcquireLocks;
 use crate::util::logs;
 
 use super::config::Resources;
@@ -480,7 +481,9 @@ pub async fn start_seek(
 
                     // Allow reporting from inside the future
                     let state_tx = &state_tx;
-                    let worker = &worker;
+                    let worker = worker
+                        .clone()
+                        .resource(ForceAcquireLocks::from(update_req.opts.force));
                     let current_state = &mut current_state;
 
                     // If we are continuing a legacy apply we also set the next target
@@ -515,7 +518,7 @@ pub async fn start_seek(
 
                             // Look for a plan to the target
                             update_status = seek_target(
-                                worker,
+                                &worker,
                                 current_state,
                                 device_target,
                                 &interrupt,

--- a/helios-state/src/tasks/app.rs
+++ b/helios-state/src/tasks/app.rs
@@ -7,6 +7,7 @@ use mahler::job;
 use mahler::state::Map;
 use mahler::task::prelude::*;
 use mahler::worker::{Uninitialized, Worker};
+use tracing::warn;
 
 use crate::common_types::{HostRuntimeDir, ImageUri, Uuid};
 use crate::models::{
@@ -17,7 +18,7 @@ use crate::oci::{Client as Docker, Error as OciError, Mount, WithContext};
 use crate::store::{self, DocumentStore};
 use crate::util::dirs::runtime_dir;
 use crate::util::fs::run_async;
-use crate::util::locking::{self, LockSet};
+use crate::util::locking::{self, ForceAcquireLocks, LockSet};
 
 use super::helpers::{
     any_images_are_pending_download, find_future_network, find_future_service, find_future_volume,
@@ -184,12 +185,17 @@ fn take_locks(
     mut app: View<App>,
     host_runtime_dir: Res<HostRuntimeDir>,
     locks: Res<LockSet>,
+    force_acquire_locks: Res<ForceAcquireLocks>,
 ) -> IO<App, io::Error> {
     app.locked = true;
     with_io(app, async move |mut app| {
         let host_runtime_dir = host_runtime_dir
             .as_ref()
             .expect("host_runtime_dir resource should be available");
+        let force_acquire_locks = force_acquire_locks
+            .as_ref()
+            .expect("force_acquire_locks should be available")
+            .enabled();
 
         // resolve a lock file for each running service whose /tmp/balena bind
         // mount lives under the host runtime directory, grouping the services
@@ -217,11 +223,15 @@ fn take_locks(
                 acc
             });
 
+        if force_acquire_locks && !service_locks.is_empty() {
+            warn!("taking locks by force per-user request");
+        }
+
         let acquired = run_async(move || {
             let locks = locks.as_ref().expect("locks resource should be available");
             let mut acquired: Vec<PathBuf> = Vec::with_capacity(service_locks.len());
             for (lock_path, svc_names) in service_locks {
-                if let Err(e) = locks.try_lock(lock_path.clone()) {
+                if let Err(e) = locks.try_lock(lock_path.clone(), force_acquire_locks) {
                     for p in acquired {
                         let _ = locks.unlock(p);
                     }
@@ -1030,7 +1040,6 @@ fn stop_service(mut svc: View<Service>, docker: Res<Docker>) -> IO<Service, OciE
         let _ = svc.flush().await;
 
         // stop the container
-        // FIXME: this needs update locks
         docker
             .container()
             .stop(&container_id)

--- a/helios-state/src/worker.rs
+++ b/helios-state/src/worker.rs
@@ -4,7 +4,7 @@ use helios_store::DocumentStore;
 
 use crate::common_types::HostRuntimeDir;
 use crate::oci::{Client as Docker, RegistryAuth};
-use crate::util::locking::LockSet;
+use crate::util::locking::{ForceAcquireLocks, LockSet};
 
 use super::models::Device;
 use super::tasks::with_device_tasks;
@@ -63,6 +63,7 @@ pub fn create(
     worker.use_resource(host_runtime_dir);
     worker.use_resource(local_store);
     worker.use_resource(LockSet::new());
+    worker.use_resource(ForceAcquireLocks::from(false));
     worker
 }
 

--- a/helios-util/src/locking.rs
+++ b/helios-util/src/locking.rs
@@ -34,71 +34,133 @@ impl From<Error> for io::Error {
     }
 }
 
+#[derive(Debug, Clone, Copy)]
+pub struct ForceAcquireLocks(bool);
+
+impl From<bool> for ForceAcquireLocks {
+    fn from(value: bool) -> Self {
+        Self(value)
+    }
+}
+
+impl ForceAcquireLocks {
+    pub fn enabled(&self) -> bool {
+        self.0
+    }
+}
+
 #[derive(Debug)]
 struct LockFile(File);
 
+enum LockOwnership {
+    Mine(LockFile),
+    Ours,
+    Theirs,
+    None,
+}
+
 impl LockFile {
-    /// Try to acquire an exclusive lock on the given path, if the file exists and was created by
-    /// helios, then it just takes an exclusive lock on the file and returns the handle
+    /// Try to acquire an exclusive lock on the given path. If the file already exists and
+    /// was created by helios, just take an exclusive lock on it and return the handle.
+    ///
+    /// When `force` is true, an existing non-helios file at `path` is atomically replaced
+    /// with a freshly created, already-locked lockfile. A helios-owned lockfile is *never*
+    /// replaced: if another helios process currently holds the flock, this returns
+    /// [`Error::WouldBlock`] regardless of `force`.
     ///
     /// This is a sync operation so use [`crate::fs::run_async`] if running in an async
-    /// context
-    pub fn create(path: &Path) -> Result<Self, Error> {
+    /// context.
+    pub fn create(path: &Path, force: bool) -> Result<Self, Error> {
         let lock_dir = path.parent().unwrap_or_else(|| Path::new("/"));
 
         ensure_exists(lock_dir)?;
 
-        tracing::trace!("acquiring lock at {}", path.display());
+        tracing::trace!("acquiring lock at {} (force={force})", path.display());
 
-        // Fast path: if the lockfile already exists with our TAG, just take an
-        // exclusive lock on it.
-        match File::open(path) {
-            Ok(file) => return Self::attach(file),
-            Err(err) if err.kind() == io::ErrorKind::NotFound => {}
-            Err(err) => return Err(err.into()),
+        // If the path exists, try to acquire an exclusive lock on it if possible.
+        // Fail with [`Error::WouldBlock`] for a non-helios lock unless using the `force`
+        match Self::try_attach(path)? {
+            LockOwnership::Mine(handle) => return Ok(handle),
+            LockOwnership::Ours => return Err(Error::WouldBlock),
+            LockOwnership::Theirs if !force => return Err(Error::WouldBlock),
+            LockOwnership::Theirs | LockOwnership::None => {}
         }
 
-        // Slow path: create the lockfile via a tempfile + hard link so that
-        // creation is atomic with respect to other processes.
+        // Acquire a fresh lockfile via a tempfile so creation is atomic with
+        // respect to other processes.
         let (tmp_path, mut tmp_file) =
             safe_create_tempfile(lock_dir, |name| format!("tmp-{name}.lock").into())?;
 
-        let res = (|| -> io::Result<()> {
-            tmp_file.write_all(&TAG)?;
-            tmp_file.flush()?;
-            tmp_file.sync_all()?;
+        let res = Self::try_install(&tmp_path, &mut tmp_file, path, force);
 
-            // hard linking to lock_path is atomic and fails with EEXIST if the
-            // path was created concurrently by another process.
-            linkat(AT_FDCWD, &tmp_path, AT_FDCWD, path, AtFlags::empty())
-                .map_err(|err| io::Error::from_raw_os_error(err as i32))
-        })();
-
-        // always remove the tempfile, ignoring errors
+        // Always try to remove the tempfile
         let _ = fs::remove_file(&tmp_path);
 
         match res {
-            Ok(()) => Self::attach(File::open(path)?),
-            Err(err) if err.kind() == io::ErrorKind::AlreadyExists => {
+            Ok(()) => return Ok(LockFile(tmp_file)),
+            Err(err) if !force && err.kind() == io::ErrorKind::AlreadyExists => {
                 // another process won the race to create the lockfile; attach
                 // to whatever is at lock_path now.
-                Self::attach(File::open(path)?)
             }
-            Err(err) => Err(err.into()),
+            Err(err) => return Err(err.into()),
+        }
+
+        match Self::try_attach(path)? {
+            LockOwnership::Mine(handle) => Ok(handle),
+            _ => Err(Error::WouldBlock),
         }
     }
 
-    fn attach(mut file: File) -> Result<LockFile, Error> {
+    /// Stamp the TAG into a freshly-created tempfile, take the flock on it,
+    /// and move it to the final location at `path`.
+    ///
+    /// With `force`, uses [`fs::rename`] (replaces an existing entry).
+    /// Without `force`, uses [`linkat`] (fails with `EEXIST` if `path` was
+    /// created concurrently).
+    fn try_install(
+        tmp_path: &Path,
+        tmp_file: &mut File,
+        dst_path: &Path,
+        force: bool,
+    ) -> io::Result<()> {
+        tmp_file.write_all(&TAG)?;
+        tmp_file.flush()?;
+        tmp_file.sync_all()?;
+
+        tmp_file.try_lock().map_err(|err| match err {
+            TryLockError::WouldBlock => io::Error::from(io::ErrorKind::WouldBlock),
+            TryLockError::Error(err) => err,
+        })?;
+
+        if force {
+            fs::rename(tmp_path, dst_path)
+        } else {
+            linkat(AT_FDCWD, tmp_path, AT_FDCWD, dst_path, AtFlags::empty())
+                .map_err(|err| io::Error::from_raw_os_error(err as i32))
+        }
+    }
+
+    /// Open `path` and classify what's there.
+    fn try_attach(path: &Path) -> io::Result<LockOwnership> {
+        let mut file = match File::open(path) {
+            Ok(f) => f,
+            Err(err) if err.kind() == io::ErrorKind::NotFound => {
+                return Ok(LockOwnership::None);
+            }
+            Err(err) => return Err(err),
+        };
+
         let mut buf = [0u8; TAG.len()];
         let n = file.read(&mut buf)?;
         if n != TAG.len() || buf != TAG {
-            return Err(Error::WouldBlock);
+            return Ok(LockOwnership::Theirs);
         }
-        file.try_lock().map_err(|err| match err {
-            TryLockError::WouldBlock => Error::WouldBlock,
-            TryLockError::Error(err) => Error::IO(err),
-        })?;
-        Ok(LockFile(file))
+
+        match file.try_lock() {
+            Ok(()) => Ok(LockOwnership::Mine(LockFile(file))),
+            Err(TryLockError::WouldBlock) => Ok(LockOwnership::Ours),
+            Err(TryLockError::Error(err)) => Err(err),
+        }
     }
 
     /// Release the lock handle, dropping the exclusive filesystem lock
@@ -128,11 +190,13 @@ impl LockSet {
     }
 
     /// Try to acquire an exclusive lock on the given path, if the file exists and was created by
-    /// helios, then it just takes an exclusive lock on the file and stores the handle
+    /// helios, then it just takes an exclusive lock on the file and stores the handle.
+    ///
+    /// See [`LockFile::create`] for the semantics of `force`.
     ///
     /// This is a sync operation so use [`crate::fs::run_async`] if running in an async
     /// context
-    pub fn try_lock(&self, path: PathBuf) -> Result<(), Error> {
+    pub fn try_lock(&self, path: PathBuf, force: bool) -> Result<(), Error> {
         assert!(path.is_absolute());
 
         let mut locks = self.locks.lock().unwrap_or_else(|p| p.into_inner());
@@ -140,7 +204,7 @@ impl LockSet {
         match locks.entry(path.clone()) {
             Entry::Occupied(_) => Err(Error::WouldBlock),
             Entry::Vacant(entry) => {
-                let lockfile = LockFile::create(path.as_ref())?;
+                let lockfile = LockFile::create(path.as_ref(), force)?;
                 entry.insert(lockfile);
 
                 Ok(())
@@ -177,6 +241,7 @@ impl LockSet {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::os::unix::fs::MetadataExt;
     use std::thread;
     use tempfile::tempdir;
 
@@ -185,7 +250,7 @@ mod tests {
         let dir = tempdir().unwrap();
         let lock_path = dir.path().join("updates.lock");
 
-        let handle = LockFile::create(&lock_path).unwrap();
+        let handle = LockFile::create(&lock_path, false).unwrap();
 
         assert!(lock_path.exists());
         let contents = fs::read(&lock_path).unwrap();
@@ -199,8 +264,8 @@ mod tests {
         let dir = tempdir().unwrap();
         let lock_path = dir.path().join("updates.lock");
 
-        let first = LockFile::create(&lock_path).unwrap();
-        let err = LockFile::create(&lock_path).unwrap_err();
+        let first = LockFile::create(&lock_path, false).unwrap();
+        let err = LockFile::create(&lock_path, false).unwrap_err();
         assert!(matches!(err, Error::WouldBlock), "got {err:?}");
 
         first.unlock();
@@ -211,8 +276,8 @@ mod tests {
         let dir = tempdir().unwrap();
         let lock_path = dir.path().join("updates.lock");
 
-        LockFile::create(&lock_path).unwrap().unlock();
-        let handle = LockFile::create(&lock_path).unwrap();
+        LockFile::create(&lock_path, false).unwrap().unlock();
+        let handle = LockFile::create(&lock_path, false).unwrap();
         handle.unlock();
     }
 
@@ -223,7 +288,7 @@ mod tests {
 
         File::create(&lock_path).unwrap();
 
-        let err = LockFile::create(&lock_path).unwrap_err();
+        let err = LockFile::create(&lock_path, false).unwrap_err();
         assert!(matches!(err, Error::WouldBlock), "got {err:?}");
     }
 
@@ -233,7 +298,7 @@ mod tests {
         let lock_path = dir.path().join("updates.lock");
         fs::create_dir(&lock_path).unwrap();
 
-        let err = LockFile::create(&lock_path).unwrap_err();
+        let err = LockFile::create(&lock_path, false).unwrap_err();
         assert!(matches!(&err, Error::IO(e) if e.kind() == io::ErrorKind::IsADirectory),);
     }
 
@@ -242,7 +307,7 @@ mod tests {
         let dir = tempdir().unwrap();
         let lock_path = dir.path().join("missing").join("updates.lock");
 
-        let handle = LockFile::create(&lock_path).unwrap();
+        let handle = LockFile::create(&lock_path, false).unwrap();
         handle.unlock();
     }
 
@@ -251,7 +316,7 @@ mod tests {
         let dir = tempdir().unwrap();
         let lock_path = dir.path().join("updates.lock");
 
-        let handle = LockFile::create(&lock_path).unwrap();
+        let handle = LockFile::create(&lock_path, false).unwrap();
 
         let leftovers: Vec<_> = fs::read_dir(dir.path())
             .unwrap()
@@ -271,7 +336,7 @@ mod tests {
         let threads: Vec<_> = (0..8)
             .map(|_| {
                 let lock_path = lock_path.clone();
-                thread::spawn(move || LockFile::create(&lock_path))
+                thread::spawn(move || LockFile::create(&lock_path, false))
             })
             .collect();
 
@@ -296,14 +361,73 @@ mod tests {
     }
 
     #[test]
+    fn force_acquire_replaces_externally_created_lockfile() {
+        let dir = tempdir().unwrap();
+        let lock_path = dir.path().join("updates.lock");
+
+        let mut external = File::create(&lock_path).unwrap();
+        external.write_all(b"not the tag").unwrap();
+        drop(external);
+
+        let handle = LockFile::create(&lock_path, true).unwrap();
+        let contents = fs::read(&lock_path).unwrap();
+        assert_eq!(contents, TAG.to_vec());
+
+        // The replaced file is a fresh inode; a concurrent non-force acquire
+        // should now see WouldBlock from our flock.
+        let err = LockFile::create(&lock_path, false).unwrap_err();
+        assert!(matches!(err, Error::WouldBlock), "got {err:?}");
+
+        handle.unlock();
+    }
+
+    #[test]
+    fn force_acquire_attaches_to_stale_helios_lockfile() {
+        let dir = tempdir().unwrap();
+        let lock_path = dir.path().join("updates.lock");
+
+        // A previous helios run left its lockfile on disk but is no longer
+        // holding the flock. Force should attach to it, not replace it.
+        LockFile::create(&lock_path, false).unwrap().unlock();
+        fs::write(&lock_path, TAG).unwrap();
+        let inode_before = fs::metadata(&lock_path).unwrap().ino();
+
+        let handle = LockFile::create(&lock_path, true).unwrap();
+        let inode_after = fs::metadata(&lock_path).unwrap().ino();
+        assert_eq!(inode_before, inode_after, "force should not replace inode");
+        handle.unlock();
+    }
+
+    #[test]
+    fn force_acquire_fails_when_another_helios_holds_lock() {
+        let dir = tempdir().unwrap();
+        let lock_path = dir.path().join("updates.lock");
+
+        let held = LockFile::create(&lock_path, false).unwrap();
+        let err = LockFile::create(&lock_path, true).unwrap_err();
+        assert!(matches!(err, Error::WouldBlock), "got {err:?}");
+        held.unlock();
+    }
+
+    #[test]
+    fn force_acquire_succeeds_when_no_existing_lockfile() {
+        let dir = tempdir().unwrap();
+        let lock_path = dir.path().join("updates.lock");
+
+        let handle = LockFile::create(&lock_path, true).unwrap();
+        assert_eq!(fs::read(&lock_path).unwrap(), TAG.to_vec());
+        handle.unlock();
+    }
+
+    #[test]
     fn lockset_try_lock_fails_when_path_already_in_set() {
         let dir = tempdir().unwrap();
         let path = dir.path().join("a.lock");
 
         let set = LockSet::new();
-        set.try_lock(path.clone()).unwrap();
+        set.try_lock(path.clone(), false).unwrap();
 
-        let err = set.try_lock(path).unwrap_err();
+        let err = set.try_lock(path, false).unwrap_err();
         assert!(matches!(err, Error::WouldBlock), "got {err:?}");
     }
 
@@ -321,11 +445,11 @@ mod tests {
         let path = dir.path().join("a.lock");
 
         let set = LockSet::new();
-        set.try_lock(path.clone()).unwrap();
+        set.try_lock(path.clone(), false).unwrap();
         set.unlock(path.clone()).unwrap();
 
         // Holding the file lock would have made this fail with WouldBlock.
-        LockFile::create(&path).unwrap().unlock();
+        LockFile::create(&path, false).unwrap().unlock();
     }
 
     #[test]
@@ -334,7 +458,7 @@ mod tests {
         let path = dir.path().join("a.lock");
 
         let set = LockSet::new();
-        set.try_lock(path.clone()).unwrap();
+        set.try_lock(path.clone(), false).unwrap();
         assert!(path.exists());
 
         set.unlock(path.clone()).unwrap();
@@ -347,7 +471,7 @@ mod tests {
         let path = dir.path().join("a.lock");
 
         let set = LockSet::new();
-        set.try_lock(path.clone()).unwrap();
+        set.try_lock(path.clone(), false).unwrap();
 
         // Remove the lockfile out from under the set; unlock should still succeed.
         fs::remove_file(&path).unwrap();

--- a/helios-util/src/locking.rs
+++ b/helios-util/src/locking.rs
@@ -200,7 +200,9 @@ impl LockSet {
     }
 
     /// Try to acquire an exclusive lock on the given path, if the file exists and was created by
-    /// helios, then it just takes an exclusive lock on the file and stores the handle.
+    /// helios, then it just takes an exclusive lock on the file and stores the handle.  
+    ///
+    /// If an entry for the lock already exists on the set, the method returns without an error (idempotency).
     ///
     /// See [`LockFile::create`] for the semantics of `force`.
     ///
@@ -212,7 +214,7 @@ impl LockSet {
         let mut locks = self.locks.lock().unwrap_or_else(|p| p.into_inner());
 
         match locks.entry(path.clone()) {
-            Entry::Occupied(_) => Err(Error::WouldBlock),
+            Entry::Occupied(_) => Ok(()),
             Entry::Vacant(entry) => {
                 let lockfile = LockFile::create(path.as_ref(), force)?;
                 entry.insert(lockfile);
@@ -473,15 +475,13 @@ mod tests {
     }
 
     #[test]
-    fn lockset_try_lock_fails_when_path_already_in_set() {
+    fn lockset_try_lock_succeeds_when_path_already_in_set() {
         let dir = tempdir().unwrap();
         let path = dir.path().join("a.lock");
 
         let set = LockSet::new();
         set.try_lock(path.clone(), false).unwrap();
-
-        let err = set.try_lock(path, false).unwrap_err();
-        assert!(matches!(err, Error::WouldBlock), "got {err:?}");
+        set.try_lock(path, false).unwrap();
     }
 
     #[test]

--- a/helios-util/src/locking.rs
+++ b/helios-util/src/locking.rs
@@ -77,6 +77,16 @@ impl LockFile {
 
         tracing::trace!("acquiring lock at {} (force={force})", path.display());
 
+        // When forcing, take an exclusive flock on the parent directory
+        // before touching `path`. This prevents two helios processes from stepping on each-other
+        let _dir_guard = if force {
+            let f = File::open(lock_dir)?;
+            f.lock()?;
+            Some(f)
+        } else {
+            None
+        };
+
         // If the path exists, try to acquire an exclusive lock on it if possible.
         // Fail with [`Error::WouldBlock`] for a non-helios lock unless using the `force`
         match Self::try_attach(path)? {
@@ -407,6 +417,49 @@ mod tests {
         let err = LockFile::create(&lock_path, true).unwrap_err();
         assert!(matches!(err, Error::WouldBlock), "got {err:?}");
         held.unlock();
+    }
+
+    #[test]
+    fn concurrent_force_acquires_do_not_overlap() {
+        use std::sync::Arc;
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        use std::time::Duration;
+
+        let dir = tempdir().unwrap();
+        let lock_path = dir.path().join("updates.lock");
+        // External file so every force-acquire goes through the install
+        // path (until the first one replaces it with a helios-owned file).
+        fs::write(&lock_path, b"not the tag").unwrap();
+
+        let held = Arc::new(AtomicUsize::new(0));
+        let max_concurrent = Arc::new(AtomicUsize::new(0));
+
+        let threads: Vec<_> = (0..8)
+            .map(|_| {
+                let lock_path = lock_path.clone();
+                let held = Arc::clone(&held);
+                let max_concurrent = Arc::clone(&max_concurrent);
+                thread::spawn(move || {
+                    if let Ok(handle) = LockFile::create(&lock_path, true) {
+                        let n = held.fetch_add(1, Ordering::SeqCst) + 1;
+                        max_concurrent.fetch_max(n, Ordering::SeqCst);
+                        thread::sleep(Duration::from_millis(10));
+                        held.fetch_sub(1, Ordering::SeqCst);
+                        handle.unlock();
+                    }
+                })
+            })
+            .collect();
+
+        for t in threads {
+            t.join().unwrap();
+        }
+
+        assert_eq!(
+            max_concurrent.load(Ordering::SeqCst),
+            1,
+            "more than one force-acquire held the lock simultaneously"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Poll requests triggered with `force: true` now tell the worker to force acquire locks if taken by the user app. Locking will still fail if the lock is being held by another helios process to prevent creating inconsistent 

This also makes `LockSet::try_lock` idempotent to avoid issues with cancelling target state apply

Change-type: patch