### PR TITLE
Support service.extra_hosts

### DIFF
--- a/helios-oci/src/container.rs
+++ b/helios-oci/src/container.rs
@@ -274,6 +274,19 @@ impl<N> TryFrom<ContainerInspectResponse> for LocalContainer<N> {
             .as_mut()
             .and_then(|hc| hc.cpu_shares.take())
             .unwrap_or(0);
+        // Engine reports each entry as `host:ip`; split on the first `:` so
+        // IPv6 addresses remain untouched.
+        let extra_hosts = host_config
+            .as_mut()
+            .and_then(|hc| hc.extra_hosts.take())
+            .unwrap_or_default()
+            .into_iter()
+            .filter_map(|entry| {
+                entry
+                    .split_once(':')
+                    .map(|(host, ip)| (host.to_string(), ip.to_string()))
+            })
+            .collect::<HashMap<_, _>>();
         let init = host_config.as_mut().and_then(|hc| hc.init.take());
         // Only recognize `none`/`host` from host_config: for user networks Docker also
         // populates `network_mode` with the first network name, which would otherwise
@@ -427,6 +440,7 @@ impl<N> TryFrom<ContainerInspectResponse> for LocalContainer<N> {
             cpu_shares,
             domainname,
             environment,
+            extra_hosts,
             healthcheck,
             hostname,
             init,
@@ -1165,6 +1179,11 @@ pub struct ContainerConfig {
     /// Maximum number of process IDs allowed in the container
     pub pids_limit: Option<i64>,
 
+    /// Extra entries added to the container's `/etc/hosts`, each in the
+    /// engine's `host:ip` form.
+    #[serde(skip_serializing_if = "HashMap::is_empty")]
+    pub extra_hosts: HashMap<String, String>,
+
     /// Network endpoint configurations, ordered by connection priority.
     ///
     /// Mutually exclusive with `network_mode`.
@@ -1197,6 +1216,7 @@ impl PartialEq for ContainerConfig {
             && self.cpu_shares == other.cpu_shares
             && self.domainname == other.domainname
             && self.environment == other.environment
+            && self.extra_hosts == other.extra_hosts
             && self.healthcheck == other.healthcheck
             && self.hostname == other.hostname
             && self.init == other.init
@@ -1240,6 +1260,7 @@ impl From<ContainerConfig> for ContainerCreateBody {
             cpu_shares,
             domainname,
             environment,
+            extra_hosts,
             healthcheck,
             hostname,
             init,
@@ -1333,6 +1354,12 @@ impl From<ContainerConfig> for ContainerCreateBody {
             cpu_realtime_period: non_zero(cpu_rt_period),
             cpu_realtime_runtime: non_zero(cpu_rt_runtime),
             cpu_shares: non_zero(cpu_shares),
+            extra_hosts: (!extra_hosts.is_empty()).then(|| {
+                extra_hosts
+                    .into_iter()
+                    .map(|(host, ip)| format!("{host}:{ip}"))
+                    .collect()
+            }),
             init,
             memory: non_zero(mem_limit),
             memory_reservation: non_zero(mem_reservation),
@@ -1687,6 +1714,63 @@ mod tests {
         assert_eq!(hc.oom_score_adj, Some(-500));
         assert_eq!(hc.pids_limit, Some(100));
         assert_eq!(hc.shm_size, Some(67108864));
+    }
+
+    #[test]
+    fn inspect_reads_extra_hosts() {
+        let resp = ContainerInspectResponse {
+            id: Some("cid".to_string()),
+            name: Some("/svc".to_string()),
+            image: Some("img".to_string()),
+            created: Some("2026-01-01T00:00:00Z".to_string()),
+            host_config: Some(HostConfig {
+                extra_hosts: Some(vec![
+                    "foo:127.0.0.1".to_string(),
+                    "bar:8.8.8.8".to_string(),
+                    "v6:2001:db8::1".to_string(),
+                    "other-v6:::1".to_string(),
+                ]),
+                ..Default::default()
+            }),
+            state: Some(bollard::models::ContainerState {
+                status: Some(ContainerStateStatusEnum::RUNNING),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let c: LocalContainer = resp.try_into().unwrap();
+        assert_eq!(
+            c.config.extra_hosts,
+            HashMap::from([
+                ("foo".to_string(), "127.0.0.1".to_string()),
+                ("bar".to_string(), "8.8.8.8".to_string()),
+                ("v6".to_string(), "2001:db8::1".to_string()),
+                ("other-v6".to_string(), "::1".to_string()),
+            ])
+        );
+    }
+
+    #[test]
+    fn container_create_body_emits_extra_hosts() {
+        let cfg = ContainerConfig {
+            extra_hosts: HashMap::from([
+                ("foo".to_string(), "127.0.0.1".to_string()),
+                ("bar".to_string(), "8.8.8.8".to_string()),
+            ]),
+            ..Default::default()
+        };
+        let body: ContainerCreateBody = cfg.into();
+        let hc = body.host_config.unwrap();
+        let mut hosts = hc.extra_hosts.unwrap();
+        hosts.sort();
+        assert_eq!(
+            hosts,
+            vec!["bar:8.8.8.8".to_string(), "foo:127.0.0.1".to_string()]
+        );
+
+        // An empty map should not emit an ExtraHosts entry on the engine request
+        let empty: ContainerCreateBody = ContainerConfig::default().into();
+        assert_eq!(empty.host_config.unwrap().extra_hosts, None);
     }
 
     #[test]

--- a/helios-remote-model/src/lib.rs
+++ b/helios-remote-model/src/lib.rs
@@ -678,6 +678,48 @@ mod tests {
     }
 
     #[test]
+    fn test_rejects_target_service_with_invalid_extra_hosts() {
+        let json = json!({
+            "name": "my-device",
+            "apps": {
+                "app-one": {
+                    "id": 1,
+                    "name": "my-app",
+                    "releases": {
+                        "c8b48659434e80a8b3adc0c5ad1e347a": {
+                            "id": 7,
+                            "services": {
+                                "main": {
+                                    "id": 3,
+                                    "image_id": 4,
+                                    "image": "registry2.balena-cloud.com/v2/8a961e0325a37441f33091743fa40a4c@sha256:0f3169ee8672222eb775b032cb3b2d06ef8eafa23a970643052bb67ac1fc5cd9",
+                                    "composition": {
+                                        "extra_hosts": ["noseparator"]
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+            }
+        });
+
+        let device: Device = serde_json::from_value(json).unwrap();
+        let rejection = match device.apps.get(&Uuid::from("app-one")) {
+            Some(App::Rejected(r)) => r,
+            other => panic!("app-one should be rejected, got {other:?}"),
+        };
+        assert_eq!(
+            rejection.release,
+            Uuid::from("c8b48659434e80a8b3adc0c5ad1e347a"),
+        );
+        assert_eq!(
+            rejection.reason,
+            "services.main.composition.extra_hosts: entry `noseparator` must be in `host:ip` or `host=ip` form",
+        );
+    }
+
+    #[test]
     fn test_rejects_target_service_with_invalid_labels() {
         let json = json!({
             "name": "my-device",

--- a/helios-remote-model/src/service/mod.rs
+++ b/helios-remote-model/src/service/mod.rs
@@ -137,6 +137,10 @@ pub struct ServiceComposition {
     #[serde(default)]
     pub oom_score_adj: Option<i64>,
 
+    /// Extra `/etc/hosts` entries as a hostname -> IP map.
+    #[serde(default, deserialize_with = "deserialize_extra_hosts")]
+    pub extra_hosts: Option<HashMap<String, String>>,
+
     #[serde(default)]
     pub pids_limit: Option<i64>,
 
@@ -172,6 +176,45 @@ where
         .map(validate_cpus)
         .transpose()
         .map_err(serde::de::Error::custom)
+}
+
+/// Deserialize Compose `extra_hosts` from a list of `host:ip`/`host=ip`
+/// strings or a `host: ip` mapping into a hostname -> IP map.
+fn deserialize_extra_hosts<'de, D>(
+    deserializer: D,
+) -> Result<Option<HashMap<String, String>>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    #[derive(Deserialize)]
+    #[serde(untagged)]
+    enum ExtraHosts {
+        List(Vec<String>),
+        Map(HashMap<String, String>),
+    }
+
+    let Some(raw) = Option::<ExtraHosts>::deserialize(deserializer)? else {
+        return Ok(None);
+    };
+
+    let map = match raw {
+        ExtraHosts::Map(map) => map,
+        ExtraHosts::List(entries) => entries
+            .into_iter()
+            .map(|entry| {
+                // The hostname can't contain `:` or `=`, so the first of either
+                // separates host from IP
+                let sep = entry.find([':', '=']).ok_or_else(|| {
+                    serde::de::Error::custom(format!(
+                        "entry `{entry}` must be in `host:ip` or `host=ip` form"
+                    ))
+                })?;
+                Ok((entry[..sep].to_string(), entry[sep + 1..].to_string()))
+            })
+            .collect::<Result<_, D::Error>>()?,
+    };
+
+    Ok(Some(map))
 }
 
 #[cfg(test)]
@@ -358,6 +401,52 @@ mod tests {
         assert_eq!(comp.pids_limit, Some(100));
         assert_eq!(comp.shm_size, Some(67108864));
         assert_eq!(comp.stop_grace_period, Some(30));
+    }
+
+    #[test]
+    fn composition_extra_hosts_default_unset() {
+        let comp: ServiceComposition = serde_json::from_value(serde_json::json!({})).unwrap();
+        assert_eq!(comp.extra_hosts, None);
+    }
+
+    #[test]
+    fn composition_extra_hosts_accepts_list_with_either_separator() {
+        let comp: ServiceComposition = serde_json::from_value(serde_json::json!({
+            "extra_hosts": ["foo=127.0.0.1", "bar:8.8.8.8", "v6:2001:db8::1"],
+        }))
+        .unwrap();
+        assert_eq!(
+            comp.extra_hosts,
+            Some(HashMap::from([
+                ("foo".to_string(), "127.0.0.1".to_string()),
+                ("bar".to_string(), "8.8.8.8".to_string()),
+                ("v6".to_string(), "2001:db8::1".to_string()),
+            ]))
+        );
+    }
+
+    #[test]
+    fn composition_extra_hosts_accepts_mapping() {
+        let comp: ServiceComposition = serde_json::from_value(serde_json::json!({
+            "extra_hosts": {"foo": "127.0.0.1", "bar": "8.8.8.8"},
+        }))
+        .unwrap();
+        assert_eq!(
+            comp.extra_hosts,
+            Some(HashMap::from([
+                ("foo".to_string(), "127.0.0.1".to_string()),
+                ("bar".to_string(), "8.8.8.8".to_string()),
+            ]))
+        );
+    }
+
+    #[test]
+    fn composition_extra_hosts_rejects_entry_without_separator() {
+        let err = serde_json::from_value::<ServiceComposition>(serde_json::json!({
+            "extra_hosts": ["noseparator"],
+        }))
+        .unwrap_err();
+        assert!(err.to_string().contains("host:ip"), "{err}");
     }
 
     #[test]

--- a/helios-state/src/models/service/mod.rs
+++ b/helios-state/src/models/service/mod.rs
@@ -245,6 +245,7 @@ impl From<RemoteServiceTarget> for ServiceTarget {
                 cpu_shares: composition.cpu_shares.unwrap_or(0),
                 domainname: composition.domainname,
                 environment,
+                extra_hosts: composition.extra_hosts.unwrap_or_default(),
                 hostname: composition.hostname,
                 init: composition.init,
                 labels,


### PR DESCRIPTION
Compose accepts entries as both host:ip and host=ip while the engine expects host:ip, so = is converted to : if exists during deserialization time at the remote-model layer.

Change-type: patch