### PR TITLE
Parse Compose duration strings using go-parse-duration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -897,6 +897,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "go-parse-duration"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "558b88954871f5e5b2af0e62e2e176c8bde7a6c2c4ed41b13d138d96da2e2cbd"
+
+[[package]]
 name = "h2"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1037,6 +1043,7 @@ dependencies = [
 name = "helios-remote-model"
 version = "0.25.7"
 dependencies = [
+ "go-parse-duration",
  "helios-util",
  "indexmap",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ fastrand = "2.4.1"
 regex = "1.12"
 pretty_assertions = "1.4.1"
 tar = "0.4"
+go-parse-duration = "0.1"
 
 [workspace.dependencies.nix]
 version = "0.31"

--- a/helios-remote-model/Cargo.toml
+++ b/helios-remote-model/Cargo.toml
@@ -15,6 +15,7 @@ version.workspace = true
 [dependencies]
 helios-util.workspace = true
 
+go-parse-duration.workspace = true
 indexmap.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/helios-remote-model/src/duration.rs
+++ b/helios-remote-model/src/duration.rs
@@ -1,0 +1,152 @@
+use go_parse_duration::parse_duration;
+use serde::{Deserialize, Deserializer};
+
+/// Compose/Go-style duration shapes accepted from the remote backend: a Go
+/// `time.ParseDuration` string such as `"1m30s"`, or a bare integer kept for
+/// backward compatibility with state already delivered as a number.
+#[derive(Deserialize)]
+#[serde(untagged)]
+enum Duration {
+    Int(i64),
+    Str(String),
+}
+
+impl Duration {
+    /// Parse a Go `time.ParseDuration` string into whole nanoseconds.
+    fn parse_str<E: serde::de::Error>(s: &str) -> Result<i64, E> {
+        parse_duration(s).map_err(|e| E::custom(format!("invalid duration `{s}`: {e:?}")))
+    }
+}
+
+/// Defines a duration wrapper storing canonical nanoseconds.
+/// - `$name`: the duration wrapper type name
+/// - `$nanos_per_unit`: the number of nanoseconds per unit
+macro_rules! duration {
+    ($(#[$doc:meta])* $name:ident, $nanos_per_unit:expr) => {
+        $(#[$doc])*
+        #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+        pub struct $name(i64);
+
+        impl $name {
+            /// Whole units in this type's named unit, truncated toward zero.
+            pub fn to_i64(self) -> i64 {
+                self.0 / $nanos_per_unit
+            }
+        }
+
+        impl<'de> Deserialize<'de> for $name {
+            fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+            where
+                D: Deserializer<'de>,
+            {
+                Ok($name(match Duration::deserialize(deserializer)? {
+                    Duration::Int(v) => v * $nanos_per_unit,
+                    Duration::Str(s) => Duration::parse_str(&s)?,
+                }))
+            }
+        }
+    };
+}
+
+duration!(
+    /// Bare int is nanoseconds, as in Engine healthcheck
+    DurationNanos, 1
+);
+duration!(
+    /// Bare int is seconds, as in `stop_grace_period`
+    DurationSecs, 1_000_000_000
+);
+duration!(
+    /// Bare int is microseconds, as in `cpu_rt_period` and `cpu_rt_runtime`
+    DurationMicros, 1_000
+);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn nanos_string_parses_with_go_semantics() {
+        assert_eq!(
+            DurationNanos::deserialize(json!("30s")).unwrap(),
+            DurationNanos(30_000_000_000)
+        );
+        assert_eq!(
+            DurationNanos::deserialize(json!("1m30s")).unwrap(),
+            DurationNanos(90_000_000_000)
+        );
+        assert_eq!(
+            DurationNanos::deserialize(json!("1500ms")).unwrap(),
+            DurationNanos(1_500_000_000)
+        );
+        // Microseconds use the `us` unit (Compose supports us/ms/s/m/h)
+        assert_eq!(
+            DurationNanos::deserialize(json!("5us")).unwrap(),
+            DurationNanos(5_000)
+        );
+        // Units can combine without a separator per Compose spec
+        assert_eq!(
+            DurationNanos::deserialize(json!("1h5m30s20ms")).unwrap(),
+            DurationNanos(3_930_020_000_000)
+        );
+    }
+
+    #[test]
+    fn bare_int_unit_is_per_type() {
+        assert_eq!(
+            DurationNanos::deserialize(json!(5_000_000_000i64)).unwrap(),
+            DurationNanos(5_000_000_000)
+        );
+        assert_eq!(
+            DurationSecs::deserialize(json!(30)).unwrap(),
+            DurationSecs(30_000_000_000)
+        );
+        assert_eq!(
+            DurationMicros::deserialize(json!(950_000)).unwrap(),
+            DurationMicros(950_000_000)
+        );
+    }
+
+    #[test]
+    fn string_form_parses_for_every_unit() {
+        assert_eq!(
+            DurationSecs::deserialize(json!("1m30s")).unwrap(),
+            DurationSecs(90_000_000_000)
+        );
+        assert_eq!(
+            DurationMicros::deserialize(json!("400ms")).unwrap(),
+            DurationMicros(400_000_000)
+        );
+    }
+
+    #[test]
+    fn conversions_truncate_toward_zero() {
+        assert_eq!(DurationNanos(1_500_000_000).to_i64(), 1_500_000_000);
+        assert_eq!(DurationSecs(1_500_000_000).to_i64(), 1);
+        assert_eq!(DurationMicros(1_500_000_500).to_i64(), 1_500_000);
+    }
+
+    #[test]
+    fn absent_is_none() {
+        assert_eq!(
+            Option::<DurationNanos>::deserialize(json!(null)).unwrap(),
+            None
+        );
+        assert_eq!(
+            Option::<DurationSecs>::deserialize(json!(null)).unwrap(),
+            None
+        );
+        assert_eq!(
+            Option::<DurationMicros>::deserialize(json!(null)).unwrap(),
+            None
+        );
+    }
+
+    #[test]
+    fn garbage_string_is_rejected() {
+        assert!(DurationNanos::deserialize(json!("15x")).is_err());
+        assert!(DurationSecs::deserialize(json!("abc")).is_err());
+        assert!(DurationMicros::deserialize(json!("abc")).is_err());
+    }
+}

--- a/helios-remote-model/src/lib.rs
+++ b/helios-remote-model/src/lib.rs
@@ -11,11 +11,13 @@ use std::{
     ops::{Deref, DerefMut},
 };
 
+mod duration;
 mod labels;
 mod network;
 mod service;
 mod volume;
 
+pub use duration::{DurationMicros, DurationNanos, DurationSecs};
 pub use labels::*;
 pub use network::*;
 pub use service::*;

--- a/helios-remote-model/src/service/healthcheck.rs
+++ b/helios-remote-model/src/service/healthcheck.rs
@@ -1,3 +1,4 @@
+use crate::duration::DurationNanos;
 use serde::{Deserialize, Deserializer};
 
 /// Service healthcheck as delivered by the remote backend. Durations are in
@@ -12,10 +13,10 @@ use serde::{Deserialize, Deserializer};
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Healthcheck {
     pub test: Option<Vec<String>>,
-    pub interval: Option<i64>,
-    pub timeout: Option<i64>,
-    pub start_period: Option<i64>,
-    pub start_interval: Option<i64>,
+    pub interval: Option<DurationNanos>,
+    pub timeout: Option<DurationNanos>,
+    pub start_period: Option<DurationNanos>,
+    pub start_interval: Option<DurationNanos>,
     pub retries: Option<i64>,
 }
 
@@ -29,10 +30,14 @@ enum Test {
 #[derive(Deserialize, Default)]
 struct RawHealthcheck {
     test: Option<Test>,
-    interval: Option<i64>,
-    timeout: Option<i64>,
-    start_period: Option<i64>,
-    start_interval: Option<i64>,
+    #[serde(default)]
+    interval: Option<DurationNanos>,
+    #[serde(default)]
+    timeout: Option<DurationNanos>,
+    #[serde(default)]
+    start_period: Option<DurationNanos>,
+    #[serde(default)]
+    start_interval: Option<DurationNanos>,
     retries: Option<i64>,
     #[serde(default)]
     disable: bool,
@@ -150,7 +155,7 @@ mod tests {
         let hc: Healthcheck =
             serde_json::from_value(json!({"test": [], "interval": 30000000000i64})).unwrap();
         assert_eq!(hc.test, None);
-        assert_eq!(hc.interval, Some(30_000_000_000));
+        assert_eq!(hc.interval.map(DurationNanos::to_i64), Some(30_000_000_000));
     }
 
     #[test]
@@ -164,10 +169,40 @@ mod tests {
             "retries": 3,
         }))
         .unwrap();
-        assert_eq!(hc.interval, Some(30_000_000_000));
-        assert_eq!(hc.timeout, Some(5_000_000_000));
-        assert_eq!(hc.start_period, Some(10_000_000_000));
-        assert_eq!(hc.start_interval, Some(1_000_000_000));
+        assert_eq!(hc.interval.map(DurationNanos::to_i64), Some(30_000_000_000));
+        assert_eq!(hc.timeout.map(DurationNanos::to_i64), Some(5_000_000_000));
+        assert_eq!(
+            hc.start_period.map(DurationNanos::to_i64),
+            Some(10_000_000_000)
+        );
+        assert_eq!(
+            hc.start_interval.map(DurationNanos::to_i64),
+            Some(1_000_000_000)
+        );
+        assert_eq!(hc.retries, Some(3));
+    }
+
+    #[test]
+    fn durations_parse_compose_strings() {
+        let hc: Healthcheck = serde_json::from_value(json!({
+            "test": "true",
+            "interval": "30s",
+            "timeout": "5000ms",
+            "start_period": "10000000us",
+            "start_interval": "1000000000ns",
+            "retries": 3,
+        }))
+        .unwrap();
+        assert_eq!(hc.interval.map(DurationNanos::to_i64), Some(30_000_000_000));
+        assert_eq!(hc.timeout.map(DurationNanos::to_i64), Some(5_000_000_000));
+        assert_eq!(
+            hc.start_period.map(DurationNanos::to_i64),
+            Some(10_000_000_000)
+        );
+        assert_eq!(
+            hc.start_interval.map(DurationNanos::to_i64),
+            Some(1_000_000_000)
+        );
         assert_eq!(hc.retries, Some(3));
     }
 

--- a/helios-remote-model/src/service/mod.rs
+++ b/helios-remote-model/src/service/mod.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 
+use crate::duration::{DurationMicros, DurationSecs};
 use serde::{Deserialize, Deserializer};
 
 use crate::common_types::{Environment, ImageUri, Value};
@@ -54,10 +55,10 @@ pub struct ServiceComposition {
     pub cpuset: Option<String>,
 
     #[serde(default)]
-    pub cpu_rt_period: Option<i64>,
+    pub cpu_rt_period: Option<DurationMicros>,
 
     #[serde(default)]
-    pub cpu_rt_runtime: Option<i64>,
+    pub cpu_rt_runtime: Option<DurationMicros>,
 
     #[serde(default)]
     pub cpu_shares: Option<i64>,
@@ -110,7 +111,7 @@ pub struct ServiceComposition {
     pub shm_size: Option<i64>,
 
     #[serde(default)]
-    pub stop_grace_period: Option<i64>,
+    pub stop_grace_period: Option<DurationSecs>,
 
     #[serde(default)]
     pub stop_signal: Option<String>,
@@ -225,6 +226,20 @@ mod tests {
     fn composition_defaults_restart_to_always() {
         let comp: ServiceComposition = serde_json::from_value(serde_json::json!({})).unwrap();
         assert_eq!(comp.restart, RestartPolicy::Always);
+    }
+
+    #[test]
+    fn composition_parses_stop_grace_period_string() {
+        let comp: ServiceComposition =
+            serde_json::from_value(serde_json::json!({"stop_grace_period": "15s"})).unwrap();
+        assert_eq!(comp.stop_grace_period.map(DurationSecs::to_i64), Some(15));
+    }
+
+    #[test]
+    fn composition_parses_stop_grace_period_int() {
+        let comp: ServiceComposition =
+            serde_json::from_value(serde_json::json!({"stop_grace_period": 30})).unwrap();
+        assert_eq!(comp.stop_grace_period.map(DurationSecs::to_i64), Some(30));
     }
 
     #[test]
@@ -391,8 +406,14 @@ mod tests {
             "stop_grace_period": 30,
         }))
         .unwrap();
-        assert_eq!(comp.cpu_rt_period, Some(1000000));
-        assert_eq!(comp.cpu_rt_runtime, Some(950000));
+        assert_eq!(
+            comp.cpu_rt_period.map(DurationMicros::to_i64),
+            Some(1000000)
+        );
+        assert_eq!(
+            comp.cpu_rt_runtime.map(DurationMicros::to_i64),
+            Some(950000)
+        );
         assert_eq!(comp.cpu_shares, Some(2048));
         assert_eq!(comp.cpus, Some(1.5));
         assert_eq!(comp.mem_limit, Some(1073741824));
@@ -400,7 +421,35 @@ mod tests {
         assert_eq!(comp.oom_score_adj, Some(-500));
         assert_eq!(comp.pids_limit, Some(100));
         assert_eq!(comp.shm_size, Some(67108864));
-        assert_eq!(comp.stop_grace_period, Some(30));
+        assert_eq!(comp.stop_grace_period.map(DurationSecs::to_i64), Some(30));
+    }
+
+    #[test]
+    fn composition_number_fields_parse_cpu_rt_duration_strings() {
+        let comp: ServiceComposition = serde_json::from_value(serde_json::json!({
+            "cpu_rt_period": "1000000us",
+            "cpu_rt_runtime": "1s",
+        }))
+        .unwrap();
+        assert_eq!(
+            comp.cpu_rt_period.map(DurationMicros::to_i64),
+            Some(1000000)
+        );
+        assert_eq!(
+            comp.cpu_rt_runtime.map(DurationMicros::to_i64),
+            Some(1000000)
+        );
+
+        let comp2: ServiceComposition = serde_json::from_value(serde_json::json!({
+            "cpu_rt_period": "900ms",
+            "cpu_rt_runtime": "200000ns",
+        }))
+        .unwrap();
+        assert_eq!(
+            comp2.cpu_rt_period.map(DurationMicros::to_i64),
+            Some(900000)
+        );
+        assert_eq!(comp2.cpu_rt_runtime.map(DurationMicros::to_i64), Some(200));
     }
 
     #[test]

--- a/helios-state/src/models/service/mod.rs
+++ b/helios-state/src/models/service/mod.rs
@@ -7,9 +7,9 @@ use crate::oci::{
     NetworkMode, NetworkSettings, RestartPolicy,
 };
 use crate::remote_model::{
-    BindPropagation as RemoteBindPropagation, Cgroup as RemoteCgroup, Mount as RemoteMount,
-    NetworkMode as RemoteNetworkMode, RestartPolicy as RemoteRestartPolicy,
-    Service as RemoteServiceTarget,
+    BindPropagation as RemoteBindPropagation, Cgroup as RemoteCgroup, DurationMicros,
+    DurationNanos, DurationSecs, Mount as RemoteMount, NetworkMode as RemoteNetworkMode,
+    RestartPolicy as RemoteRestartPolicy, Service as RemoteServiceTarget,
 };
 
 use super::image::ImageRef;
@@ -240,8 +240,14 @@ impl From<RemoteServiceTarget> for ServiceTarget {
                 cgroup_parent: composition.cgroup_parent,
                 command,
                 cpuset: composition.cpuset,
-                cpu_rt_period: composition.cpu_rt_period.unwrap_or(0),
-                cpu_rt_runtime: composition.cpu_rt_runtime.unwrap_or(0),
+                cpu_rt_period: composition
+                    .cpu_rt_period
+                    .map(DurationMicros::to_i64)
+                    .unwrap_or(0),
+                cpu_rt_runtime: composition
+                    .cpu_rt_runtime
+                    .map(DurationMicros::to_i64)
+                    .unwrap_or(0),
                 cpu_shares: composition.cpu_shares.unwrap_or(0),
                 domainname: composition.domainname,
                 environment,
@@ -267,7 +273,7 @@ impl From<RemoteServiceTarget> for ServiceTarget {
                 restart_policy,
                 runtime: composition.runtime,
                 shm_size: composition.shm_size,
-                stop_grace_period: composition.stop_grace_period,
+                stop_grace_period: composition.stop_grace_period.map(DurationSecs::to_i64),
                 stop_signal: composition.stop_signal,
                 tty: composition.tty,
                 user: composition.user,
@@ -282,10 +288,10 @@ impl From<RemoteServiceTarget> for ServiceTarget {
                     // the service to inherit the image's HEALTHCHECK
                     let hc = Healthcheck {
                         test: h.test,
-                        interval: h.interval,
-                        timeout: h.timeout,
-                        start_period: h.start_period,
-                        start_interval: h.start_interval,
+                        interval: h.interval.map(DurationNanos::to_i64),
+                        timeout: h.timeout.map(DurationNanos::to_i64),
+                        start_period: h.start_period.map(DurationNanos::to_i64),
+                        start_interval: h.start_interval.map(DurationNanos::to_i64),
                         retries: h.retries,
                     };
                     (!hc.is_empty()).then_some(hc)


### PR DESCRIPTION
Pre-v18 Supervisor parsed duration strings into integer on-device. Helios didn't do this which is a regression. Use go-parse-duration which compose-go uses, to parse duration strings into i64.

See: https://docs.docker.com/reference/compose-file/extension/#specifying-durations
Relates-to: https://github.com/balena-os/balena-supervisor/issues/2525
Change-type: patch