### PR TITLE
Parse Compose byte values using parse-size

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1046,6 +1046,7 @@ dependencies = [
  "go-parse-duration",
  "helios-util",
  "indexmap",
+ "parse-size",
  "serde",
  "serde_json",
  "serde_path_to_error",
@@ -1723,6 +1724,12 @@ name = "parking"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
+
+[[package]]
+name = "parse-size"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "487f2ccd1e17ce8c1bfab3a65c89525af41cfad4c8659021a1e9a2aacd73b89b"
 
 [[package]]
 name = "percent-encoding"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ regex = "1.12"
 pretty_assertions = "1.4.1"
 tar = "0.4"
 go-parse-duration = "0.1"
+parse-size = "1.1"
 
 [workspace.dependencies.nix]
 version = "0.31"

--- a/helios-remote-model/Cargo.toml
+++ b/helios-remote-model/Cargo.toml
@@ -17,6 +17,7 @@ helios-util.workspace = true
 
 go-parse-duration.workspace = true
 indexmap.workspace = true
+parse-size.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 serde_path_to_error.workspace = true

--- a/helios-remote-model/src/byte_size.rs
+++ b/helios-remote-model/src/byte_size.rs
@@ -1,0 +1,123 @@
+use parse_size::Config;
+use serde::{Deserialize, Deserializer};
+
+/// Compose/Docker byte-value shapes accepted from the remote backend: a byte
+/// string such as `"1g"`, `"512mb"`, or `"1.5GiB"`, or a bare integer of bytes
+/// kept for backward compatibility with state already delivered as a number.
+///
+/// Strings are parsed with binary (1024-based) units to match
+/// `docker/go-units` `RAMInBytes` and compose-go: units are case-insensitive,
+/// the `b` suffix is optional (so `k`, `kb`, `kib` are all kilobytes), and an
+/// absent unit means bytes.
+#[derive(Deserialize)]
+#[serde(untagged)]
+enum RawByteSize {
+    Int(i64),
+    Str(String),
+}
+
+/// A byte quantity from the remote model, stored canonically as whole bytes.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ByteSize(i64);
+
+impl ByteSize {
+    /// Whole bytes, truncated toward zero.
+    pub fn to_bytes(self) -> i64 {
+        self.0
+    }
+
+    /// Parse a Docker `RAMInBytes`-style string (e.g. `"1g"`, `"512mb"`) into
+    /// whole bytes using binary (1024-based) units.
+    fn parse_str<E: serde::de::Error>(s: &str) -> Result<i64, E> {
+        let bytes = Config::new()
+            .with_binary()
+            .parse_size(s)
+            .map_err(|e| E::custom(format!("invalid byte value `{s}`: {e}")))?;
+        i64::try_from(bytes).map_err(|_| E::custom(format!("byte value `{s}` exceeds i64::MAX")))
+    }
+}
+
+impl<'de> Deserialize<'de> for ByteSize {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        Ok(ByteSize(match RawByteSize::deserialize(deserializer)? {
+            RawByteSize::Int(v) => v,
+            RawByteSize::Str(s) => ByteSize::parse_str(&s)?,
+        }))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn bare_int_is_bytes() {
+        assert_eq!(
+            ByteSize::deserialize(json!(67108864)).unwrap(),
+            ByteSize(67108864)
+        );
+        assert_eq!(ByteSize::deserialize(json!(0)).unwrap(), ByteSize(0));
+    }
+
+    #[test]
+    fn string_uses_binary_units() {
+        assert_eq!(ByteSize::deserialize(json!("1b")).unwrap(), ByteSize(1));
+        assert_eq!(ByteSize::deserialize(json!("1k")).unwrap(), ByteSize(1024));
+        assert_eq!(
+            ByteSize::deserialize(json!("1m")).unwrap(),
+            ByteSize(1024 * 1024)
+        );
+        assert_eq!(
+            ByteSize::deserialize(json!("1g")).unwrap(),
+            ByteSize(1024 * 1024 * 1024)
+        );
+    }
+
+    #[test]
+    fn unit_suffix_and_case_are_flexible() {
+        // `b`, `i`, and case are all optional/ignored for the unit letter.
+        for s in ["1g", "1G", "1gb", "1GB", "1gib", "1GiB"] {
+            assert_eq!(
+                ByteSize::deserialize(json!(s)).unwrap(),
+                ByteSize(1024 * 1024 * 1024),
+                "{s}"
+            );
+        }
+    }
+
+    #[test]
+    fn fractional_values_truncate_toward_zero() {
+        assert_eq!(
+            ByteSize::deserialize(json!("0.5g")).unwrap(),
+            ByteSize(536870912)
+        );
+        assert_eq!(
+            ByteSize::deserialize(json!("1.5k")).unwrap(),
+            ByteSize(1536)
+        );
+    }
+
+    #[test]
+    fn optional_space_between_number_and_unit() {
+        assert_eq!(
+            ByteSize::deserialize(json!("512 mb")).unwrap(),
+            ByteSize(512 * 1024 * 1024)
+        );
+    }
+
+    #[test]
+    fn absent_is_none() {
+        assert_eq!(Option::<ByteSize>::deserialize(json!(null)).unwrap(), None);
+    }
+
+    #[test]
+    fn garbage_string_is_rejected() {
+        assert!(ByteSize::deserialize(json!("abc")).is_err());
+        assert!(ByteSize::deserialize(json!("10x")).is_err());
+        assert!(ByteSize::deserialize(json!("-5m")).is_err());
+    }
+}

--- a/helios-remote-model/src/lib.rs
+++ b/helios-remote-model/src/lib.rs
@@ -11,12 +11,14 @@ use std::{
     ops::{Deref, DerefMut},
 };
 
+mod byte_size;
 mod duration;
 mod labels;
 mod network;
 mod service;
 mod volume;
 
+pub use byte_size::ByteSize;
 pub use duration::{DurationMicros, DurationNanos, DurationSecs};
 pub use labels::*;
 pub use network::*;

--- a/helios-remote-model/src/service/mod.rs
+++ b/helios-remote-model/src/service/mod.rs
@@ -3,6 +3,7 @@ use std::collections::HashMap;
 use crate::duration::{DurationMicros, DurationSecs};
 use serde::{Deserialize, Deserializer};
 
+use crate::byte_size::ByteSize;
 use crate::common_types::{Environment, ImageUri, Value};
 
 mod cgroup;
@@ -90,10 +91,10 @@ pub struct ServiceComposition {
     pub labels: Labels,
 
     #[serde(default)]
-    pub mem_limit: Option<i64>,
+    pub mem_limit: Option<ByteSize>,
 
     #[serde(default)]
-    pub mem_reservation: Option<i64>,
+    pub mem_reservation: Option<ByteSize>,
 
     #[serde(default)]
     pub privileged: bool,
@@ -108,7 +109,7 @@ pub struct ServiceComposition {
     pub runtime: Option<String>,
 
     #[serde(default)]
-    pub shm_size: Option<i64>,
+    pub shm_size: Option<ByteSize>,
 
     #[serde(default)]
     pub stop_grace_period: Option<DurationSecs>,
@@ -416,11 +417,14 @@ mod tests {
         );
         assert_eq!(comp.cpu_shares, Some(2048));
         assert_eq!(comp.cpus, Some(1.5));
-        assert_eq!(comp.mem_limit, Some(1073741824));
-        assert_eq!(comp.mem_reservation, Some(536870912));
+        assert_eq!(comp.mem_limit.map(ByteSize::to_bytes), Some(1073741824));
+        assert_eq!(
+            comp.mem_reservation.map(ByteSize::to_bytes),
+            Some(536870912)
+        );
         assert_eq!(comp.oom_score_adj, Some(-500));
         assert_eq!(comp.pids_limit, Some(100));
-        assert_eq!(comp.shm_size, Some(67108864));
+        assert_eq!(comp.shm_size.map(ByteSize::to_bytes), Some(67108864));
         assert_eq!(comp.stop_grace_period.map(DurationSecs::to_i64), Some(30));
     }
 
@@ -450,6 +454,22 @@ mod tests {
             Some(900000)
         );
         assert_eq!(comp2.cpu_rt_runtime.map(DurationMicros::to_i64), Some(200));
+    }
+
+    #[test]
+    fn composition_byte_fields_parse_strings() {
+        let comp: ServiceComposition = serde_json::from_value(serde_json::json!({
+            "mem_limit": "1g",
+            "mem_reservation": "512mb",
+            "shm_size": "64MiB",
+        }))
+        .unwrap();
+        assert_eq!(comp.mem_limit.map(ByteSize::to_bytes), Some(1073741824));
+        assert_eq!(
+            comp.mem_reservation.map(ByteSize::to_bytes),
+            Some(536870912)
+        );
+        assert_eq!(comp.shm_size.map(ByteSize::to_bytes), Some(67108864));
     }
 
     #[test]

--- a/helios-state/src/models/service/mod.rs
+++ b/helios-state/src/models/service/mod.rs
@@ -7,7 +7,7 @@ use crate::oci::{
     NetworkMode, NetworkSettings, RestartPolicy,
 };
 use crate::remote_model::{
-    BindPropagation as RemoteBindPropagation, Cgroup as RemoteCgroup, DurationMicros,
+    BindPropagation as RemoteBindPropagation, ByteSize, Cgroup as RemoteCgroup, DurationMicros,
     DurationNanos, DurationSecs, Mount as RemoteMount, NetworkMode as RemoteNetworkMode,
     RestartPolicy as RemoteRestartPolicy, Service as RemoteServiceTarget,
 };
@@ -255,8 +255,11 @@ impl From<RemoteServiceTarget> for ServiceTarget {
                 hostname: composition.hostname,
                 init: composition.init,
                 labels,
-                mem_limit: composition.mem_limit.unwrap_or(0),
-                mem_reservation: composition.mem_reservation.unwrap_or(0),
+                mem_limit: composition.mem_limit.map(ByteSize::to_bytes).unwrap_or(0),
+                mem_reservation: composition
+                    .mem_reservation
+                    .map(ByteSize::to_bytes)
+                    .unwrap_or(0),
                 // Compose ships fractional CPU; engine takes nano-CPUs. The
                 // value is validated at deserialization time, so a plain cast
                 // is safe here. Round to nearest to avoid drift on values like
@@ -272,7 +275,7 @@ impl From<RemoteServiceTarget> for ServiceTarget {
                 read_only: composition.read_only,
                 restart_policy,
                 runtime: composition.runtime,
-                shm_size: composition.shm_size,
+                shm_size: composition.shm_size.map(ByteSize::to_bytes),
                 stop_grace_period: composition.stop_grace_period.map(DurationSecs::to_i64),
                 stop_signal: composition.stop_signal,
                 tty: composition.tty,


### PR DESCRIPTION
Similar to https://github.com/balena-io/helios/pull/122 for Duration parsing , we need to parse incoming Byte strings into integers readable by the Engine

- Accept Compose/Docker byte-value strings such as "1g", "512mb", "1.5GiB"  or bare ints for mem_limit, mem_reservation, and shm_size
- Add a Bytes wrapper deserializing using parse-size crate in 1024-based mode to match docker's RAMInBytes, with a to_bytes conversion

See: https://docs.docker.com/reference/compose-file/extension/#specifying-byte-values
Change-type: patch