### PR TITLE
Support service depends_on startup ordering

### DIFF
--- a/helios-oci/src/container.rs
+++ b/helios-oci/src/container.rs
@@ -475,10 +475,10 @@ impl<N> TryFrom<ContainerInspectResponse> for LocalContainer<N> {
             .context("container creation date should be a valid date")?;
 
         let state = value.state.ok_or("container state should not be nil")?;
-        let healthy = state
+        let health = state
             .health
             .and_then(|health| health.status)
-            .map(|status| status == HealthStatusEnum::HEALTHY)
+            .map(Health::from)
             .unwrap_or_default();
         let status = state
             .status
@@ -489,7 +489,7 @@ impl<N> TryFrom<ContainerInspectResponse> for LocalContainer<N> {
         let state = ContainerState {
             created,
             error: state.error,
-            healthy,
+            health,
             status,
             exit_code,
         };
@@ -531,15 +531,35 @@ impl From<ContainerStateStatusEnum> for ContainerStatus {
     }
 }
 
+/// Container health as reported by the engine's healthcheck.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub enum Health {
+    #[default]
+    None,
+    Starting,
+    Healthy,
+    Unhealthy,
+}
+
+impl From<HealthStatusEnum> for Health {
+    fn from(value: HealthStatusEnum) -> Self {
+        use HealthStatusEnum::*;
+        match value {
+            EMPTY | NONE => Health::None,
+            STARTING => Health::Starting,
+            HEALTHY => Health::Healthy,
+            UNHEALTHY => Health::Unhealthy,
+        }
+    }
+}
+
 /// Container state summary
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ContainerState {
     /// The container runtime status
     pub status: ContainerStatus,
-    /// Container health status, `true` means the container
-    /// is healthy, `false` means the container health status is
-    /// undetermined
-    pub healthy: bool,
+    /// Container health as reported by the engine's healthcheck
+    pub health: Health,
     /// Container creation date
     pub created: DateTime,
     /// Last error message from the container
@@ -1570,6 +1590,41 @@ mod tests {
     fn inspect_exit_code_is_none_when_absent() {
         let c: LocalContainer = inspect_with_mounts(vec![]).try_into().unwrap();
         assert_eq!(c.state.exit_code, None);
+    }
+
+    #[test]
+    fn inspect_maps_health_status() {
+        let with_status = |status: HealthStatusEnum| ContainerInspectResponse {
+            id: Some("cid".to_string()),
+            name: Some("/svc".to_string()),
+            image: Some("img".to_string()),
+            created: Some("2026-01-01T00:00:00Z".to_string()),
+            host_config: Some(HostConfig::default()),
+            state: Some(bollard::models::ContainerState {
+                status: Some(ContainerStateStatusEnum::RUNNING),
+                health: Some(bollard::models::Health {
+                    status: Some(status),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        for (status, expected) in [
+            (HealthStatusEnum::HEALTHY, Health::Healthy),
+            (HealthStatusEnum::UNHEALTHY, Health::Unhealthy),
+            (HealthStatusEnum::STARTING, Health::Starting),
+            (HealthStatusEnum::NONE, Health::None),
+        ] {
+            let c: LocalContainer = with_status(status).try_into().unwrap();
+            assert_eq!(c.state.health, expected);
+        }
+    }
+
+    #[test]
+    fn inspect_health_is_none_when_absent() {
+        let c: LocalContainer = inspect_with_mounts(vec![]).try_into().unwrap();
+        assert_eq!(c.state.health, Health::None);
     }
 
     #[test]

--- a/helios-oci/src/container.rs
+++ b/helios-oci/src/container.rs
@@ -484,12 +484,14 @@ impl<N> TryFrom<ContainerInspectResponse> for LocalContainer<N> {
             .status
             .ok_or("container status should not be nil")?
             .into();
+        let exit_code = state.exit_code;
 
         let state = ContainerState {
             created,
             error: state.error,
             healthy,
             status,
+            exit_code,
         };
 
         Ok(Self {
@@ -542,6 +544,11 @@ pub struct ContainerState {
     pub created: DateTime,
     /// Last error message from the container
     pub error: Option<String>,
+    /// Exit code of the container's main process, as reported by the engine.
+    /// The engine reports `0` for a container that has not exited (still running
+    /// or never started), so this is only a meaningful exit status once `status`
+    /// is `Stopped`.
+    pub exit_code: Option<i64>,
 }
 
 /// Cgroup namespace mode for a container.
@@ -1537,6 +1544,32 @@ mod tests {
         assert!(!c.config.privileged);
         assert!(!c.config.read_only);
         assert!(!c.config.tty);
+    }
+
+    #[test]
+    fn inspect_captures_exit_code() {
+        let resp = ContainerInspectResponse {
+            id: Some("cid".to_string()),
+            name: Some("/svc".to_string()),
+            image: Some("img".to_string()),
+            created: Some("2026-01-01T00:00:00Z".to_string()),
+            host_config: Some(HostConfig::default()),
+            state: Some(bollard::models::ContainerState {
+                status: Some(ContainerStateStatusEnum::EXITED),
+                exit_code: Some(0),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let c: LocalContainer = resp.try_into().unwrap();
+        assert_eq!(c.state.status, ContainerStatus::Stopped);
+        assert_eq!(c.state.exit_code, Some(0));
+    }
+
+    #[test]
+    fn inspect_exit_code_is_none_when_absent() {
+        let c: LocalContainer = inspect_with_mounts(vec![]).try_into().unwrap();
+        assert_eq!(c.state.exit_code, None);
     }
 
     #[test]

--- a/helios-oci/src/lib.rs
+++ b/helios-oci/src/lib.rs
@@ -13,7 +13,7 @@ pub use registry::RegistryAuth;
 
 mod container;
 pub use container::{
-    BindPropagation, Cgroup, Container, ContainerConfig, ContainerState, ContainerStatus,
+    BindPropagation, Cgroup, Container, ContainerConfig, ContainerState, ContainerStatus, Health,
     Healthcheck, LocalContainer, Mount, NetworkMode, NetworkSettings, RestartPolicy,
 };
 

--- a/helios-remote-model/src/lib.rs
+++ b/helios-remote-model/src/lib.rs
@@ -1087,4 +1087,42 @@ mod tests {
         let svc = release.services.get("my-service").unwrap();
         assert_eq!(svc.composition.volumes.iter().count(), 2);
     }
+
+    #[test]
+    fn test_release_accepts_depends_on_short_and_long_form() {
+        let release: Release = serde_json::from_value(json!({
+            "services": {
+                "web": {
+                    "id": 1, "image": "ubuntu:latest",
+                    "composition": {"depends_on": {"db": {"condition": "service_healthy"}}}
+                },
+                "db": {
+                    "id": 2, "image": "ubuntu:latest",
+                    "composition": {"depends_on": ["migrate"]}
+                },
+                "migrate": {"id": 3, "image": "ubuntu:latest"}
+            },
+            "volumes": {}, "networks": {}
+        }))
+        .unwrap();
+        assert_eq!(release.services.len(), 3);
+        assert_eq!(
+            release.services["web"]
+                .composition
+                .depends_on
+                .get("db")
+                .unwrap()
+                .condition,
+            DependsOnCondition::ServiceHealthy
+        );
+        assert_eq!(
+            release.services["db"]
+                .composition
+                .depends_on
+                .get("migrate")
+                .unwrap()
+                .condition,
+            DependsOnCondition::ServiceStarted
+        );
+    }
 }

--- a/helios-remote-model/src/lib.rs
+++ b/helios-remote-model/src/lib.rs
@@ -345,6 +345,54 @@ pub struct Release {
     pub networks: HashMap<String, Network>,
 }
 
+/// Validate the cross-service `depends_on` graph of a release.
+/// Every referenced service must exist and the graph must be acyclic.
+fn validate_depends_on(services: &HashMap<String, Service>) -> Result<(), String> {
+    for (svc_name, svc) in services {
+        for dep_name in svc.composition.depends_on.keys() {
+            if !services.contains_key(dep_name) {
+                return Err(format!(
+                    "service '{svc_name}' depends on undefined service '{dep_name}'"
+                ));
+            }
+        }
+    }
+
+    // `Visiting` marks a node on the current path
+    // `Done` marks a fully explored node.
+    enum Mark {
+        Visiting,
+        Done,
+    }
+
+    fn visit<'a>(
+        name: &'a str,
+        services: &'a HashMap<String, Service>,
+        marks: &mut HashMap<&'a str, Mark>,
+    ) -> Result<(), String> {
+        match marks.get(name) {
+            Some(Mark::Done) => return Ok(()),
+            Some(Mark::Visiting) => {
+                return Err(format!("circular depends_on involving service '{name}'"));
+            }
+            None => {}
+        }
+
+        marks.insert(name, Mark::Visiting);
+        for dep_name in services[name].composition.depends_on.keys() {
+            visit(dep_name, services, marks)?;
+        }
+        marks.insert(name, Mark::Done);
+        Ok(())
+    }
+
+    let mut marks: HashMap<&str, Mark> = HashMap::new();
+    for svc_name in services.keys() {
+        visit(svc_name, services, &mut marks)?;
+    }
+    Ok(())
+}
+
 impl<'de> Deserialize<'de> for Release {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
@@ -402,6 +450,9 @@ impl<'de> Deserialize<'de> for Release {
             }
         }
 
+        // Verify service dependencies are valid at the release level.
+        validate_depends_on(&raw.services).map_err(serde::de::Error::custom)?;
+
         // Add a default network to isolate app services
         if needs_default_net {
             raw.networks.entry("default".to_string()).or_default();
@@ -419,6 +470,63 @@ impl<'de> Deserialize<'de> for Release {
 mod tests {
     use super::*;
     use serde_json::json;
+
+    #[test]
+    fn rejects_depends_on_undefined_service() {
+        let err = serde_json::from_value::<Release>(json!({
+            "services": {
+                "web": {"id": 1, "image": "alpine:latest", "composition": {"depends_on": ["ghost"]}}
+            }
+        }))
+        .unwrap_err();
+        assert!(
+            err.to_string().contains("undefined service"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn rejects_depends_on_cycle() {
+        let err = serde_json::from_value::<Release>(json!({
+            "services": {
+                "a": {"id": 1, "image": "alpine:latest", "composition": {"depends_on": ["b"]}},
+                "b": {"id": 2, "image": "alpine:latest", "composition": {"depends_on": ["a"]}}
+            }
+        }))
+        .unwrap_err();
+        assert!(
+            err.to_string().contains("circular"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn rejects_depends_on_self_cycle() {
+        let err = serde_json::from_value::<Release>(json!({
+            "services": {
+                "a": {"id": 1, "image": "alpine:latest", "composition": {"depends_on": ["a"]}}
+            }
+        }))
+        .unwrap_err();
+        assert!(
+            err.to_string().contains("circular"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn accepts_acyclic_depends_on_graph() {
+        let release: Release = serde_json::from_value(json!({
+            "services": {
+                "web": {"id": 1, "image": "alpine:latest", "composition": {"depends_on": ["db", "cache"]}},
+                "db": {"id": 2, "image": "alpine:latest", "composition": {"depends_on": ["migrate"]}},
+                "cache": {"id": 3, "image": "alpine:latest", "composition": {"depends_on": ["migrate"]}},
+                "migrate": {"id": 4, "image": "alpine:latest"}
+            }
+        }))
+        .unwrap();
+        assert_eq!(release.services.len(), 4);
+    }
 
     #[test]
     fn test_accepts_empty_releases() {

--- a/helios-remote-model/src/service/depends_on.rs
+++ b/helios-remote-model/src/service/depends_on.rs
@@ -1,0 +1,191 @@
+use std::collections::HashMap;
+use std::fmt;
+use std::ops::Deref;
+
+use serde::de::{MapAccess, SeqAccess, Visitor};
+use serde::{Deserialize, Deserializer, Serialize};
+
+/// Condition under which a `depends_on` dependency is considered satisfied.
+#[derive(Serialize, Deserialize, Clone, Copy, Debug, PartialEq, Eq, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum DependsOnCondition {
+    #[default]
+    ServiceStarted, // service started
+    ServiceHealthy,               // service healthy per healthcheck
+    ServiceCompletedSuccessfully, // service exited with status 0
+}
+
+#[derive(Serialize, Clone, Debug, PartialEq, Eq)]
+pub struct LongFormDependsOn {
+    pub condition: DependsOnCondition,
+    /// When true, the dependent service is restarted after dependency restarts.
+    /// Only applies to restarts issued through Helios. Defaults false.
+    pub restart: bool,
+    /// When false, an unmet dependency only emits a warning instead of
+    /// blocking the dependent service from starting. Defaults true.
+    pub required: bool,
+}
+
+impl Default for LongFormDependsOn {
+    fn default() -> Self {
+        Self {
+            condition: DependsOnCondition::ServiceStarted,
+            restart: false,
+            required: true,
+        }
+    }
+}
+
+/// `depends_on` block on a service composition.
+///
+/// Accepts both Compose syntaxes at deserialization time:
+/// - short form: `["svc1", "svc2"]`: equivalent to each entry with
+///   `condition: service_started`, `restart: false`, `required: true`.
+/// - long form: `{ "svc1": { "condition": "service_healthy", ... } }`.
+#[derive(Serialize, Clone, Debug, PartialEq, Eq, Default)]
+pub struct DependsOn(HashMap<String, LongFormDependsOn>);
+
+impl Deref for DependsOn {
+    type Target = HashMap<String, LongFormDependsOn>;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl From<HashMap<String, LongFormDependsOn>> for DependsOn {
+    fn from(value: HashMap<String, LongFormDependsOn>) -> Self {
+        Self(value)
+    }
+}
+
+/// Parse `depends_on` from either a list of service names or a map of per-service specs.
+impl<'de> Deserialize<'de> for DependsOn {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        // Long form requires `condition` explicitly while the
+        // other fields default. A custom visitor preserves precise error
+        // messages for malformed long-form entries.
+        #[derive(Deserialize)]
+        struct LongFormDependsOnRaw {
+            condition: DependsOnCondition,
+            #[serde(default)]
+            restart: bool,
+            #[serde(default)]
+            required: Option<bool>,
+        }
+
+        struct DependsOnVisitor;
+
+        impl<'de> Visitor<'de> for DependsOnVisitor {
+            type Value = DependsOn;
+
+            fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {
+                f.write_str("a list of service names or a map of service names to dependency specs")
+            }
+
+            fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+            where
+                A: SeqAccess<'de>,
+            {
+                let mut map = HashMap::new();
+                while let Some(name) = seq.next_element::<String>()? {
+                    map.insert(name, LongFormDependsOn::default());
+                }
+                Ok(DependsOn(map))
+            }
+
+            fn visit_map<A>(self, mut access: A) -> Result<Self::Value, A::Error>
+            where
+                A: MapAccess<'de>,
+            {
+                let mut map = HashMap::new();
+                while let Some((name, spec)) =
+                    access.next_entry::<String, LongFormDependsOnRaw>()?
+                {
+                    map.insert(
+                        name,
+                        LongFormDependsOn {
+                            condition: spec.condition,
+                            restart: spec.restart,
+                            required: spec.required.unwrap_or(true),
+                        },
+                    );
+                }
+                Ok(DependsOn(map))
+            }
+        }
+
+        deserializer.deserialize_any(DependsOnVisitor)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn parses_short_form_as_service_started_with_defaults() {
+        let deps: DependsOn = serde_json::from_value(json!(["db", "redis"])).unwrap();
+        assert_eq!(deps.len(), 2);
+        let db = deps.get("db").unwrap();
+        assert_eq!(db.condition, DependsOnCondition::ServiceStarted);
+        assert!(!db.restart);
+        assert!(db.required);
+    }
+
+    #[test]
+    fn parses_long_form_with_all_conditions() {
+        let deps: DependsOn = serde_json::from_value(json!({
+            "db": {"condition": "service_healthy", "restart": true},
+            "redis": {"condition": "service_started", "required": false},
+            "migrate": {"condition": "service_completed_successfully"},
+        }))
+        .unwrap();
+        assert_eq!(
+            deps.get("db").unwrap().condition,
+            DependsOnCondition::ServiceHealthy
+        );
+        assert!(deps.get("db").unwrap().restart);
+        assert!(deps.get("db").unwrap().required);
+        assert_eq!(
+            deps.get("redis").unwrap().condition,
+            DependsOnCondition::ServiceStarted
+        );
+        assert!(!deps.get("redis").unwrap().required);
+        assert_eq!(
+            deps.get("migrate").unwrap().condition,
+            DependsOnCondition::ServiceCompletedSuccessfully
+        );
+        assert!(!deps.get("migrate").unwrap().restart);
+        assert!(deps.get("migrate").unwrap().required);
+    }
+
+    #[test]
+    fn long_form_requires_condition() {
+        let err =
+            serde_json::from_value::<DependsOn>(json!({"db": {"restart": true}})).unwrap_err();
+        assert!(
+            err.to_string().contains("condition"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn rejects_unknown_condition() {
+        let err =
+            serde_json::from_value::<DependsOn>(json!({"db": {"condition": "foo"}})).unwrap_err();
+        assert!(
+            err.to_string().contains("foo") || err.to_string().contains("variant"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn empty_short_form_yields_empty_map() {
+        let deps: DependsOn = serde_json::from_value(json!([])).unwrap();
+        assert!(deps.is_empty());
+    }
+}

--- a/helios-remote-model/src/service/mod.rs
+++ b/helios-remote-model/src/service/mod.rs
@@ -8,6 +8,7 @@ use crate::common_types::{Environment, ImageUri, Value};
 
 mod cgroup;
 mod command;
+mod depends_on;
 mod healthcheck;
 mod network_mode;
 mod networks;
@@ -16,6 +17,7 @@ mod volumes;
 
 pub use cgroup::*;
 pub use command::*;
+pub use depends_on::*;
 pub use healthcheck::*;
 pub use network_mode::*;
 pub use networks::*;
@@ -70,6 +72,9 @@ pub struct ServiceComposition {
     /// the engine takes nano_cpus and would otherwise saturate silently.
     #[serde(default, deserialize_with = "deserialize_cpus")]
     pub cpus: Option<f64>,
+
+    #[serde(default)]
+    pub depends_on: DependsOn,
 
     #[serde(default)]
     pub domainname: Option<String>,

--- a/helios-state/src/labels.rs
+++ b/helios-state/src/labels.rs
@@ -15,3 +15,6 @@ pub(crate) const LABEL_VOLUME_NAME: &str = "io.balena.volume-name";
 
 /// Label storing the service id on managed resources
 pub(crate) const LABEL_SERVICE_ID: &str = "io.balena.service-id";
+
+/// Label storing the JSON-encoded `depends_on` map for a service container.
+pub(crate) const LABEL_DEPENDS_ON: &str = "io.balena.private.depends-on";

--- a/helios-state/src/models/service/depends_on.rs
+++ b/helios-state/src/models/service/depends_on.rs
@@ -10,7 +10,10 @@ use crate::remote_model::{
 };
 
 /// Condition under which a `depends_on` dependency is considered satisfied.
-#[derive(Serialize, Deserialize, Clone, Copy, Debug, PartialEq, Eq)]
+///
+/// `Ord` gives a stable tiebreak when emitting await tasks for a dependency
+/// referenced under more than one condition.
+#[derive(Serialize, Deserialize, Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
 #[serde(rename_all = "snake_case")]
 pub enum DependsOnCondition {
     ServiceStarted,

--- a/helios-state/src/models/service/depends_on.rs
+++ b/helios-state/src/models/service/depends_on.rs
@@ -1,0 +1,114 @@
+use std::collections::HashMap;
+use std::ops::Deref;
+
+use mahler::state::State;
+use serde::{Deserialize, Serialize};
+
+use crate::remote_model::{
+    DependsOn as RemoteDependsOn, DependsOnCondition as RemoteDependsOnCondition,
+    LongFormDependsOn as RemoteLongFormDependsOn,
+};
+
+/// Condition under which a `depends_on` dependency is considered satisfied.
+#[derive(Serialize, Deserialize, Clone, Copy, Debug, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum DependsOnCondition {
+    ServiceStarted,
+    ServiceHealthy,
+    ServiceCompletedSuccessfully,
+}
+
+impl From<RemoteDependsOnCondition> for DependsOnCondition {
+    fn from(value: RemoteDependsOnCondition) -> Self {
+        match value {
+            RemoteDependsOnCondition::ServiceStarted => Self::ServiceStarted,
+            RemoteDependsOnCondition::ServiceHealthy => Self::ServiceHealthy,
+            RemoteDependsOnCondition::ServiceCompletedSuccessfully => {
+                Self::ServiceCompletedSuccessfully
+            }
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
+pub struct DependencySpec {
+    pub condition: DependsOnCondition,
+    pub restart: bool,
+    pub required: bool,
+}
+
+impl From<RemoteLongFormDependsOn> for DependencySpec {
+    fn from(value: RemoteLongFormDependsOn) -> Self {
+        Self {
+            condition: value.condition.into(),
+            restart: value.restart,
+            required: value.required,
+        }
+    }
+}
+
+/// Per-service `depends_on` map carried on `Service`. Serialized as JSON into
+/// the engine container's `LABEL_DEPENDS_ON` so that the value round-trips on
+/// container observation and does not register as state drift.
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Default)]
+#[serde(transparent)]
+pub struct DependsOn(HashMap<String, DependencySpec>);
+
+impl State for DependsOn {
+    type Target = Self;
+}
+
+impl Deref for DependsOn {
+    type Target = HashMap<String, DependencySpec>;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl From<HashMap<String, DependencySpec>> for DependsOn {
+    fn from(value: HashMap<String, DependencySpec>) -> Self {
+        Self(value)
+    }
+}
+
+impl From<RemoteDependsOn> for DependsOn {
+    fn from(value: RemoteDependsOn) -> Self {
+        Self(
+            value
+                .iter()
+                .map(|(name, spec)| (name.clone(), spec.clone().into()))
+                .collect(),
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn round_trips_through_json_label() {
+        let mut map = HashMap::new();
+        map.insert(
+            "db".to_string(),
+            DependencySpec {
+                condition: DependsOnCondition::ServiceHealthy,
+                restart: true,
+                required: false,
+            },
+        );
+        map.insert(
+            "redis".to_string(),
+            DependencySpec {
+                condition: DependsOnCondition::ServiceStarted,
+                restart: false,
+                required: true,
+            },
+        );
+        let deps: DependsOn = map.into();
+
+        let encoded = serde_json::to_string(&deps).unwrap();
+        let decoded: DependsOn = serde_json::from_str(&encoded).unwrap();
+        assert_eq!(deps, decoded);
+    }
+}

--- a/helios-state/src/models/service/mod.rs
+++ b/helios-state/src/models/service/mod.rs
@@ -1,7 +1,7 @@
 use mahler::state::State;
 use serde::{Deserialize, Serialize};
 
-use crate::labels::LABEL_SERVICE_ID;
+use crate::labels::{LABEL_DEPENDS_ON, LABEL_SERVICE_ID};
 use crate::oci::{
     self, BindPropagation, Cgroup, ContainerConfig, DateTime, Healthcheck, LocalContainer, Mount,
     NetworkMode, NetworkSettings, RestartPolicy,
@@ -15,8 +15,10 @@ use crate::remote_model::{
 use super::image::ImageRef;
 
 mod config;
+mod depends_on;
 
 pub use config::*;
+pub use depends_on::*;
 
 /// The container runtime status. This is a simplified state over what the container engine returns
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Default, PartialOrd, Ord)]
@@ -110,6 +112,10 @@ pub struct Service {
     /// Service configuration
     #[mahler(default)]
     pub config: ServiceConfig,
+
+    /// Ordering dependencies on other services in the same release.
+    #[mahler(default)]
+    pub depends_on: DependsOn,
 }
 
 impl From<Service> for ServiceTarget {
@@ -119,6 +125,7 @@ impl From<Service> for ServiceTarget {
             image,
             config,
             started,
+            depends_on,
             ..
         } = svc;
         ServiceTarget {
@@ -126,6 +133,7 @@ impl From<Service> for ServiceTarget {
             image,
             config,
             started,
+            depends_on,
         }
     }
 }
@@ -144,6 +152,8 @@ impl From<RemoteServiceTarget> for ServiceTarget {
         // merge the composition labels with the top level service labels
         // giving priority to the latter
         let labels = composition.labels.into_iter().chain(labels).collect();
+
+        let depends_on: DependsOn = composition.depends_on.into();
 
         // merge the composition environment with the top level service environment
         // giving priority to the latter
@@ -235,6 +245,7 @@ impl From<RemoteServiceTarget> for ServiceTarget {
             id,
             image: image.into(),
             started: true,
+            depends_on,
             config: ServiceConfig(ContainerConfig {
                 cgroup: composition
                     .cgroup
@@ -320,6 +331,15 @@ impl<N> From<LocalContainer<N>> for Service {
             .and_then(|id| id.parse().ok())
             .unwrap_or(0);
 
+        // Reconstruct depends_on from label. A malformed value
+        // is treated as absent.
+        let depends_on: DependsOn = container
+            .config
+            .labels
+            .remove(LABEL_DEPENDS_ON)
+            .and_then(|s| serde_json::from_str(&s).ok())
+            .unwrap_or_default();
+
         let image = ImageRef::Id(container.image.clone());
         let container_summary = Container::from((container.name.as_str(), container.state.clone()));
 
@@ -337,6 +357,7 @@ impl<N> From<LocalContainer<N>> for Service {
             installing: false,
             started,
             config,
+            depends_on,
         }
     }
 }

--- a/helios-state/src/models/service/mod.rs
+++ b/helios-state/src/models/service/mod.rs
@@ -144,6 +144,19 @@ pub struct Service {
     /// Ordering dependencies on other services in the same release.
     #[mahler(default)]
     pub depends_on: DependsOn,
+
+    /// `healthy` is ephemeral planning state set by `await_healthy`, not persisted,
+    /// and re-derived as `false` whenever current state is read from the engine.
+    /// Lets the planner gate `service_healthy` dependents deterministically.
+    #[mahler(internal, default)]
+    pub healthy: bool,
+
+    /// `completed_successfully` is ephemeral planning state set by `await_completed`,
+    /// not persisted, and re-derived as `false` whenever current state is read
+    /// from the engine.
+    /// Lets the planner gate `service_completed_successfully` dependents deterministically.
+    #[mahler(internal, default)]
+    pub completed_successfully: bool,
 }
 
 impl From<Service> for ServiceTarget {
@@ -386,6 +399,8 @@ impl<N> From<LocalContainer<N>> for Service {
             started,
             config,
             depends_on,
+            healthy: false,
+            completed_successfully: false,
         }
     }
 }

--- a/helios-state/src/models/service/mod.rs
+++ b/helios-state/src/models/service/mod.rs
@@ -44,12 +44,37 @@ impl From<oci::ContainerStatus> for ContainerStatus {
     }
 }
 
+/// Container health as reported by the engine's healthcheck
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum Health {
+    #[default]
+    None,
+    Starting,
+    Healthy,
+    Unhealthy,
+}
+
+impl From<oci::Health> for Health {
+    fn from(value: oci::Health) -> Self {
+        use oci::Health::*;
+        match value {
+            None => Self::None,
+            Starting => Self::Starting,
+            Healthy => Self::Healthy,
+            Unhealthy => Self::Unhealthy,
+        }
+    }
+}
+
 #[derive(Serialize, Deserialize, Debug, Clone, Eq, PartialEq)]
 pub struct Container {
     pub name: String,
     pub created: DateTime,
     pub status: ContainerStatus,
     pub exit_code: Option<i64>,
+    #[serde(default)]
+    pub health: Health,
 }
 
 impl Container {
@@ -60,6 +85,7 @@ impl Container {
             created: DateTime::default(),
             status: ContainerStatus::Created,
             exit_code: None,
+            health: Health::None,
         }
     }
 }
@@ -71,6 +97,7 @@ impl From<(&str, oci::ContainerState)> for Container {
             status,
             created,
             exit_code,
+            health,
             ..
         } = container_state;
 
@@ -79,6 +106,7 @@ impl From<(&str, oci::ContainerState)> for Container {
             status: status.into(),
             created,
             exit_code,
+            health: health.into(),
         }
     }
 }

--- a/helios-state/src/models/service/mod.rs
+++ b/helios-state/src/models/service/mod.rs
@@ -47,6 +47,7 @@ pub struct Container {
     pub name: String,
     pub created: DateTime,
     pub status: ContainerStatus,
+    pub exit_code: Option<i64>,
 }
 
 impl Container {
@@ -56,6 +57,7 @@ impl Container {
             name: String::default(),
             created: DateTime::default(),
             status: ContainerStatus::Created,
+            exit_code: None,
         }
     }
 }
@@ -64,13 +66,17 @@ impl From<(&str, oci::ContainerState)> for Container {
     fn from((container_name, container_state): (&str, oci::ContainerState)) -> Self {
         let container_id = container_name.to_owned();
         let oci::ContainerState {
-            status, created, ..
+            status,
+            created,
+            exit_code,
+            ..
         } = container_state;
 
         Container {
             name: container_id,
             status: status.into(),
             created,
+            exit_code,
         }
     }
 }

--- a/helios-state/src/tasks/app.rs
+++ b/helios-state/src/tasks/app.rs
@@ -8,13 +8,13 @@ use mahler::job;
 use mahler::state::Map;
 use mahler::task::prelude::*;
 use mahler::worker::{Uninitialized, Worker};
-use tracing::warn;
+use tracing::{info, warn};
 
 use crate::common_types::{HostRuntimeDir, ImageUri, Uuid};
 use crate::labels::LABEL_DEPENDS_ON;
 use crate::models::{
-    App, AppMap, AppTarget, Container, ContainerStatus, Device, ImageRef, Network, Release,
-    ReleaseTarget, Service, ServiceTarget, Volume,
+    App, AppMap, AppTarget, Container, ContainerStatus, DependsOnCondition, Device, Health,
+    ImageRef, Network, Release, ReleaseTarget, Service, ServiceTarget, Volume,
 };
 use crate::oci::{Client as Docker, Error as OciError, Mount, WithContext};
 use crate::store::{self, DocumentStore};
@@ -23,7 +23,7 @@ use crate::util::fs::run_async;
 use crate::util::locking::{self, ForceAcquireLocks, LockSet};
 
 use super::helpers::{
-    any_images_are_pending_download, dependencies_satisfied, find_future_network,
+    any_images_are_pending_download, condition_met, dependencies_satisfied, find_future_network,
     find_future_service, find_future_volume, find_installed_network, find_installed_service,
     find_installed_volume, service_matches_target, services_need_stopping,
 };
@@ -733,6 +733,8 @@ fn create_service(maybe_svc: View<Option<Service>>, Target(tgt): Target<Service>
         oci: None,
         config,
         depends_on,
+        healthy: false,
+        completed_successfully: false,
     })
 }
 
@@ -1012,6 +1014,142 @@ fn start_service(
 
         *svc = Service::from(local_container);
         svc.image = tgt_svc.image;
+
+        Ok(svc)
+    })
+}
+
+/// Emit an await task for each runtime dependency (`service_healthy` or
+/// `service_completed_successfully`) that a not-yet-started service requires
+/// but which has not reached the required state yet.
+///
+/// `service_started` dependencies are not handled here but rather by their own start.
+///
+/// As in Docker Compose, a dependency that never reaches its condition
+/// (e.g. a `restart: always` service depended on with `service_completed_successfully`)
+/// simply leaves the dependent waiting. This is user error so is not handled by helios.
+fn await_runtime_dependencies(rel: View<Release>) -> Vec<Task> {
+    let services = &rel.services;
+
+    // Collect the (dependency, condition) pairs to await: the unmet required
+    // healthy/completed conditions of not-yet-started services, deduped.
+    let mut pending: Vec<(&String, DependsOnCondition)> = Vec::new();
+    for svc in services.values() {
+        // Only services still waiting to start drive a runtime wait
+        if svc.started {
+            continue;
+        }
+        for (dep_name, spec) in svc.depends_on.iter() {
+            // started dependencies are driven by their own start; optional
+            // dependencies never block
+            if !spec.required || spec.condition == DependsOnCondition::ServiceStarted {
+                continue;
+            }
+            let met = services
+                .get(dep_name)
+                .is_some_and(|dep| condition_met(dep, spec.condition));
+            let key = (dep_name, spec.condition);
+            if !met && !pending.contains(&key) {
+                pending.push(key);
+            }
+        }
+    }
+
+    // Emit in a stable order so the plan is reproducible — `depends_on` is a
+    // HashMap whose iteration order is otherwise non-deterministic. Tiebreak on
+    // the condition for a dependency awaited under more than one.
+    pending.sort_by(|a, b| a.0.cmp(b.0).then(a.1.cmp(&b.1)));
+
+    pending
+        .into_iter()
+        .filter_map(|(dep_name, condition)| match condition {
+            DependsOnCondition::ServiceHealthy => {
+                Some(await_healthy.with_arg("service_name", dep_name))
+            }
+            DependsOnCondition::ServiceCompletedSuccessfully => {
+                Some(await_completed.with_arg("service_name", dep_name))
+            }
+            DependsOnCondition::ServiceStarted => None,
+        })
+        .collect()
+}
+
+/// Wait for a started service container to report healthy, marking it ready so
+/// the planner can sequence dependents after it.
+fn await_healthy(mut svc: View<Service>, docker: Res<Docker>) -> IO<Service, OciError> {
+    enforce!(
+        svc.started && !svc.healthy,
+        "service container should be started and not yet confirmed healthy"
+    );
+
+    svc.healthy = true;
+
+    poll_until(svc, docker, "health", |c| c.health == Health::Healthy)
+}
+
+/// Wait for a started service container to exit with status 0, marking it ready
+/// so the planner can sequence dependents after it.
+fn await_completed(mut svc: View<Service>, docker: Res<Docker>) -> IO<Service, OciError> {
+    enforce!(
+        svc.started && !svc.completed_successfully,
+        "service container should be started and not yet confirmed completed"
+    );
+
+    svc.completed_successfully = true;
+
+    poll_until(svc, docker, "completion", |c| {
+        c.status == ContainerStatus::Stopped && c.exit_code == Some(0)
+    })
+}
+
+/// Poll the engine until `is_satisfied` holds, logging poll status periodically.
+fn poll_until(
+    svc: View<Service>,
+    docker: Res<Docker>,
+    awaiting: &'static str,
+    is_satisfied: impl Fn(&Container) -> bool + Send + 'static,
+) -> IO<Service, OciError> {
+    with_io(svc, async move |mut svc| {
+        let docker = docker
+            .as_ref()
+            .expect("docker resource should be available");
+        let container_id = svc
+            .oci
+            .as_ref()
+            .map(|c| c.name.clone())
+            .expect("container should be available");
+
+        // poll the engine every second.
+        // log poll status every 15s for observability.
+        const POLL_INTERVAL: std::time::Duration = std::time::Duration::from_secs(1);
+        const LOG_EVERY_POLLS: u32 = 15;
+        let mut polls: u32 = 0;
+
+        loop {
+            let local_container = docker
+                .container()
+                .inspect(&container_id)
+                .await
+                .with_context(|| {
+                    format!("failed to inspect container while awaiting {awaiting}")
+                })?;
+            let observed = Service::from(local_container);
+            let satisfied = observed.oci.as_ref().is_some_and(&is_satisfied);
+            svc.oci = observed.oci;
+            if satisfied {
+                break;
+            }
+
+            polls += 1;
+            if polls.is_multiple_of(LOG_EVERY_POLLS)
+                && let Some(c) = svc.oci.as_ref()
+            {
+                info!("still awaiting (status={:?}, health={:?})", c.status, c.health);
+            }
+
+            let _ = svc.flush().await;
+            tokio::time::sleep(POLL_INTERVAL).await;
+        }
 
         Ok(svc)
     })
@@ -1316,6 +1454,7 @@ pub fn with_userapp_tasks<O>(worker: Worker<O, Uninitialized>) -> Worker<O, Unin
                         format!("finish release '{commit}' for app with uuid '{uuid}'")
                     },
                 ),
+                job::update(await_runtime_dependencies),
                 job::delete(remove_release).with_description(
                     |Args((uuid, commit)): Args<(Uuid, Uuid)>| {
                         format!("remove release '{commit}' for app with uuid '{uuid}'")
@@ -1387,6 +1526,16 @@ pub fn with_userapp_tasks<O>(worker: Worker<O, Uninitialized>) -> Worker<O, Unin
                 job::none(start_service).with_description(
                     |Args((_, commit, service_name)): Args<(Uuid, Uuid, String)>| {
                         format!("start service '{service_name}' for release '{commit}'")
+                    },
+                ),
+                job::none(await_healthy).with_description(
+                    |Args((_, commit, service_name)): Args<(Uuid, Uuid, String)>| {
+                        format!("await service '{service_name}' healthy for release '{commit}'")
+                    },
+                ),
+                job::none(await_completed).with_description(
+                    |Args((_, commit, service_name)): Args<(Uuid, Uuid, String)>| {
+                        format!("await service '{service_name}' completed for release '{commit}'")
                     },
                 ),
                 job::none(stop_service_when_requirements_are_met),

--- a/helios-state/src/tasks/app.rs
+++ b/helios-state/src/tasks/app.rs
@@ -1084,7 +1084,16 @@ fn await_healthy(mut svc: View<Service>, docker: Res<Docker>) -> IO<Service, Oci
 
     svc.healthy = true;
 
-    poll_until(svc, docker, "health", |c| c.health == Health::Healthy)
+    poll_until(svc, docker, "health", health_outcome)
+}
+
+/// Classify an observed container against the `service_healthy` condition.
+fn health_outcome(c: &Container) -> AwaitOutcome {
+    match c.health {
+        Health::Healthy => AwaitOutcome::Satisfied,
+        Health::Unhealthy => AwaitOutcome::Failed("unhealthy".into()),
+        Health::Starting | Health::None => AwaitOutcome::Pending,
+    }
 }
 
 /// Wait for a started service container to exit with status 0, marking it ready
@@ -1097,17 +1106,41 @@ fn await_completed(mut svc: View<Service>, docker: Res<Docker>) -> IO<Service, O
 
     svc.completed_successfully = true;
 
-    poll_until(svc, docker, "completion", |c| {
-        c.status == ContainerStatus::Stopped && c.exit_code == Some(0)
-    })
+    poll_until(svc, docker, "completion", completion_outcome)
 }
 
-/// Poll the engine until `is_satisfied` holds, logging poll status periodically.
+/// Classify an observed container against the `service_completed_successfully`
+/// condition. The exit code is only meaningful once the container has stopped.
+fn completion_outcome(c: &Container) -> AwaitOutcome {
+    if c.status != ContainerStatus::Stopped {
+        return AwaitOutcome::Pending;
+    }
+    match c.exit_code {
+        Some(0) => AwaitOutcome::Satisfied,
+        Some(code) => AwaitOutcome::Failed(format!("exited with code {code}")),
+        None => AwaitOutcome::Failed("exited with an unknown code".into()),
+    }
+}
+
+/// Outcome of evaluating an awaited dependency's observed container state.
+#[derive(Debug, PartialEq)]
+enum AwaitOutcome {
+    /// The condition is met; the dependent may start.
+    Satisfied,
+    /// The dependency reached a terminal failure (e.g. unhealthy, non-zero
+    /// exit), so the condition can never be met — fail fast with the reason.
+    Failed(String),
+    /// Not satisfied yet; keep polling.
+    Pending,
+}
+
+/// Poll the engine until `evaluate` reports the condition satisfied; a `Failed`
+/// outcome fails the task rather than polling forever.
 fn poll_until(
     svc: View<Service>,
     docker: Res<Docker>,
     awaiting: &'static str,
-    is_satisfied: impl Fn(&Container) -> bool + Send + 'static,
+    evaluate: impl Fn(&Container) -> AwaitOutcome + Send + 'static,
 ) -> IO<Service, OciError> {
     with_io(svc, async move |mut svc| {
         let docker = docker
@@ -1134,17 +1167,26 @@ fn poll_until(
                     format!("failed to inspect container while awaiting {awaiting}")
                 })?;
             let observed = Service::from(local_container);
-            let satisfied = observed.oci.as_ref().is_some_and(&is_satisfied);
+            let outcome = observed.oci.as_ref().map(&evaluate);
             svc.oci = observed.oci;
-            if satisfied {
-                break;
+            match outcome {
+                Some(AwaitOutcome::Satisfied) => break,
+                Some(AwaitOutcome::Failed(reason)) => {
+                    return Err(
+                        format!("dependency failed while awaiting {awaiting}: {reason}").into(),
+                    );
+                }
+                Some(AwaitOutcome::Pending) | None => {}
             }
 
             polls += 1;
             if polls.is_multiple_of(LOG_EVERY_POLLS)
                 && let Some(c) = svc.oci.as_ref()
             {
-                info!("still awaiting (status={:?}, health={:?})", c.status, c.health);
+                info!(
+                    "still awaiting (status={:?}, health={:?})",
+                    c.status, c.health
+                );
             }
 
             let _ = svc.flush().await;
@@ -1594,4 +1636,68 @@ pub fn with_userapp_tasks<O>(worker: Worker<O, Uninitialized>) -> Worker<O, Unin
             )
             .with_description(|| "app has an invalid target release"),
         )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn container(status: ContainerStatus, exit_code: Option<i64>, health: Health) -> Container {
+        let mut c = Container::mock();
+        c.status = status;
+        c.exit_code = exit_code;
+        c.health = health;
+        c
+    }
+
+    #[test]
+    fn health_outcome_classifies_observed_health() {
+        assert_eq!(
+            health_outcome(&container(ContainerStatus::Running, None, Health::Healthy)),
+            AwaitOutcome::Satisfied
+        );
+        // a failed healthcheck can never satisfy the condition: fail fast
+        assert_eq!(
+            health_outcome(&container(
+                ContainerStatus::Running,
+                None,
+                Health::Unhealthy
+            )),
+            AwaitOutcome::Failed("unhealthy".into())
+        );
+        assert_eq!(
+            health_outcome(&container(ContainerStatus::Running, None, Health::Starting)),
+            AwaitOutcome::Pending
+        );
+        assert_eq!(
+            health_outcome(&container(ContainerStatus::Running, None, Health::None)),
+            AwaitOutcome::Pending
+        );
+    }
+
+    #[test]
+    fn completion_outcome_classifies_exit_state() {
+        // exit code is not meaningful until the container has stopped
+        assert_eq!(
+            completion_outcome(&container(ContainerStatus::Running, Some(0), Health::None)),
+            AwaitOutcome::Pending
+        );
+        assert_eq!(
+            completion_outcome(&container(ContainerStatus::Stopped, Some(0), Health::None)),
+            AwaitOutcome::Satisfied
+        );
+        // a non-zero exit can never satisfy the condition: fail fast
+        assert_eq!(
+            completion_outcome(&container(
+                ContainerStatus::Stopped,
+                Some(137),
+                Health::None
+            )),
+            AwaitOutcome::Failed("exited with code 137".into())
+        );
+        assert_eq!(
+            completion_outcome(&container(ContainerStatus::Stopped, None, Health::None)),
+            AwaitOutcome::Failed("exited with an unknown code".into())
+        );
+    }
 }

--- a/helios-state/src/tasks/app.rs
+++ b/helios-state/src/tasks/app.rs
@@ -11,6 +11,7 @@ use mahler::worker::{Uninitialized, Worker};
 use tracing::warn;
 
 use crate::common_types::{HostRuntimeDir, ImageUri, Uuid};
+use crate::labels::LABEL_DEPENDS_ON;
 use crate::models::{
     App, AppMap, AppTarget, Container, ContainerStatus, Device, ImageRef, Network, Release,
     ReleaseTarget, Service, ServiceTarget, Volume,
@@ -718,7 +719,11 @@ fn remove_volume(vol: View<Volume>) -> View<Option<Volume>> {
 /// Create the service in memory before initiating download
 fn create_service(maybe_svc: View<Option<Service>>, Target(tgt): Target<Service>) -> View<Service> {
     let ServiceTarget {
-        id, image, config, ..
+        id,
+        image,
+        config,
+        depends_on,
+        ..
     } = tgt;
     maybe_svc.create(Service {
         id,
@@ -727,6 +732,7 @@ fn create_service(maybe_svc: View<Option<Service>>, Target(tgt): Target<Service>
         started: false,
         oci: None,
         config,
+        depends_on,
     })
 }
 
@@ -870,6 +876,15 @@ fn install_service(
 
         let mut container_config =
             std::mem::take(&mut svc.config).into_oci_config(svc.id, &svc_name, &app_uuid);
+
+        // record depends_on in container label
+        if !svc.depends_on.is_empty()
+            && let Ok(encoded) = serde_json::to_string(&svc.depends_on)
+        {
+            container_config
+                .labels
+                .insert(LABEL_DEPENDS_ON.to_string(), encoded);
+        }
 
         // Extract networks to connect later
         let mut networks = std::mem::take(&mut container_config.networks);

--- a/helios-state/src/tasks/app.rs
+++ b/helios-state/src/tasks/app.rs
@@ -23,9 +23,9 @@ use crate::util::fs::run_async;
 use crate::util::locking::{self, ForceAcquireLocks, LockSet};
 
 use super::helpers::{
-    any_images_are_pending_download, find_future_network, find_future_service, find_future_volume,
-    find_installed_network, find_installed_service, find_installed_volume, service_matches_target,
-    services_need_stopping,
+    any_images_are_pending_download, dependencies_satisfied, find_future_network,
+    find_future_service, find_future_volume, find_installed_network, find_installed_service,
+    find_installed_volume, service_matches_target, services_need_stopping,
 };
 use super::image::create_image;
 
@@ -938,7 +938,7 @@ fn install_service(
 /// A service can be started if:
 /// - The container has been created and is not already running
 /// - If updating between releases, there is no equally named service from a previous release of the same app
-/// - Any service dependencies have been started/running/healthy (TODO)
+/// - Every `depends_on` dependency is satisfied per its condition
 ///
 /// These requirements may vary a little depending on the update strategy
 fn start_service_when_requirements_are_met(
@@ -953,6 +953,8 @@ fn start_service_when_requirements_are_met(
         || device.apps.get(&app_uuid).is_some_and(|app| app.locked))
         // and any service from a previous release has already been installed
         && find_installed_service(&device, &app_uuid, &rel_uuid, &svc_name).is_none()
+        // and the service's dependencies are satisfied
+        && dependencies_satisfied(&device, &app_uuid, &rel_uuid, &tgt_svc.depends_on)
     {
         return Some(start_service.with_target(tgt_svc));
     }

--- a/helios-state/src/tasks/helpers.rs
+++ b/helios-state/src/tasks/helpers.rs
@@ -1,7 +1,7 @@
 use crate::common_types::Uuid;
 use crate::models::{
-    ContainerStatus, Device, DeviceTarget, ImageRef, Network, NetworkTarget, Service,
-    ServiceConfig, ServiceTarget, Volume, VolumeTarget,
+    ContainerStatus, DependsOn, DependsOnCondition, Device, DeviceTarget, Health, ImageRef,
+    Network, NetworkTarget, Service, ServiceConfig, ServiceTarget, Volume, VolumeTarget,
 };
 use crate::oci::Mount;
 
@@ -19,6 +19,53 @@ pub fn find_installed_service<'a>(
             .flat_map(|(_, r)| r.services.iter().find(|(k, _)| k == &service_name))
             .map(|(_, s)| s)
             .next()
+    })
+}
+
+/// Whether a dependency's current state satisfies a `depends_on` condition.
+fn condition_met(dep: &Service, condition: DependsOnCondition) -> bool {
+    match condition {
+        // The dependency has been started at least once
+        DependsOnCondition::ServiceStarted => dep.started,
+        // The dependency's healthcheck reports healthy
+        DependsOnCondition::ServiceHealthy => dep
+            .oci
+            .as_ref()
+            .is_some_and(|c| c.health == Health::Healthy),
+        // The dependency's container has exited with status 0
+        DependsOnCondition::ServiceCompletedSuccessfully => dep
+            .oci
+            .as_ref()
+            .is_some_and(|c| c.status == ContainerStatus::Stopped && c.exit_code == Some(0)),
+    }
+}
+
+/// Whether every `depends_on` entry of a service is satisfied by the current
+/// state of its dependencies in the same release. A `required` dependency must
+/// have reached its condition; an optional (`required: false`) dependency never
+/// blocks.
+///
+/// TODO: full Compose parity for optional dependencies (separate PR). Compose
+/// also *waits* for an optional dependency to resolve and warns if it fails;
+/// Helios does not wait for optional dependencies at all — the dependent starts
+/// immediately regardless of their outcome.
+pub fn dependencies_satisfied(
+    device: &Device,
+    app_uuid: &Uuid,
+    commit: &Uuid,
+    depends_on: &DependsOn,
+) -> bool {
+    let services = device
+        .apps
+        .get(app_uuid)
+        .and_then(|app| app.releases.get(commit))
+        .map(|release| &release.services);
+
+    depends_on.iter().all(|(dep_name, spec)| {
+        !spec.required
+            || services
+                .and_then(|services| services.get(dep_name))
+                .is_some_and(|dep| condition_met(dep, spec.condition))
     })
 }
 
@@ -279,4 +326,108 @@ pub fn any_images_are_pending_download(
                 })
         })
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::models::DependencySpec;
+    use serde_json::json;
+    use std::collections::HashMap;
+
+    fn device_with(services: serde_json::Value) -> Device {
+        serde_json::from_value(json!({
+            "uuid": "device-uuid",
+            "apps": {
+                "app-uuid": {
+                    "id": 1,
+                    "name": "app",
+                    "releases": {
+                        "rel-uuid": {
+                            "installed": true,
+                            "services": services,
+                        }
+                    }
+                }
+            }
+        }))
+        .unwrap()
+    }
+
+    /// Build a `depends_on` of `service_started` entries with the given
+    /// `(name, required)` pairs.
+    fn started_deps(entries: &[(&str, bool)]) -> DependsOn {
+        entries
+            .iter()
+            .map(|(name, required)| {
+                (
+                    name.to_string(),
+                    DependencySpec {
+                        condition: DependsOnCondition::ServiceStarted,
+                        restart: false,
+                        required: *required,
+                    },
+                )
+            })
+            .collect::<HashMap<_, _>>()
+            .into()
+    }
+
+    fn check(device: &Device, deps: &DependsOn) -> bool {
+        dependencies_satisfied(device, &"app-uuid".into(), &"rel-uuid".into(), deps)
+    }
+
+    #[test]
+    fn empty_depends_on_is_satisfied() {
+        let device = device_with(json!({}));
+        assert!(check(&device, &DependsOn::default()));
+    }
+
+    #[test]
+    fn satisfied_when_required_dependency_is_met() {
+        let device = device_with(json!({
+            "db": {"id": 1, "image": "alpine:latest", "started": true, "config": {}},
+        }));
+        assert!(check(&device, &started_deps(&[("db", true)])));
+    }
+
+    #[test]
+    fn blocks_on_unmet_required_dependency() {
+        let device = device_with(json!({
+            "db": {"id": 1, "image": "alpine:latest", "started": false, "config": {}},
+        }));
+        assert!(!check(&device, &started_deps(&[("db", true)])));
+    }
+
+    #[test]
+    fn proceeds_on_unmet_optional_dependency() {
+        let device = device_with(json!({
+            "db": {"id": 1, "image": "alpine:latest", "started": false, "config": {}},
+        }));
+        assert!(check(&device, &started_deps(&[("db", false)])));
+    }
+
+    #[test]
+    fn blocks_when_a_required_dependency_is_unmet_even_if_an_optional_one_is_met() {
+        let device = device_with(json!({
+            "db": {"id": 1, "image": "alpine:latest", "started": true, "config": {}},
+            "cache": {"id": 2, "image": "alpine:latest", "started": false, "config": {}},
+        }));
+        assert!(!check(
+            &device,
+            &started_deps(&[("db", false), ("cache", true)])
+        ));
+    }
+
+    #[test]
+    fn missing_required_dependency_blocks() {
+        let device = device_with(json!({}));
+        assert!(!check(&device, &started_deps(&[("db", true)])));
+    }
+
+    #[test]
+    fn missing_optional_dependency_proceeds() {
+        let device = device_with(json!({}));
+        assert!(check(&device, &started_deps(&[("db", false)])));
+    }
 }

--- a/helios-state/src/tasks/helpers.rs
+++ b/helios-state/src/tasks/helpers.rs
@@ -1,7 +1,7 @@
 use crate::common_types::Uuid;
 use crate::models::{
-    ContainerStatus, DependsOn, DependsOnCondition, Device, DeviceTarget, Health, ImageRef,
-    Network, NetworkTarget, Service, ServiceConfig, ServiceTarget, Volume, VolumeTarget,
+    ContainerStatus, DependsOn, DependsOnCondition, Device, DeviceTarget, ImageRef, Network,
+    NetworkTarget, Service, ServiceConfig, ServiceTarget, Volume, VolumeTarget,
 };
 use crate::oci::Mount;
 
@@ -23,20 +23,11 @@ pub fn find_installed_service<'a>(
 }
 
 /// Whether a dependency's current state satisfies a `depends_on` condition.
-fn condition_met(dep: &Service, condition: DependsOnCondition) -> bool {
+pub fn condition_met(dep: &Service, condition: DependsOnCondition) -> bool {
     match condition {
-        // The dependency has been started at least once
         DependsOnCondition::ServiceStarted => dep.started,
-        // The dependency's healthcheck reports healthy
-        DependsOnCondition::ServiceHealthy => dep
-            .oci
-            .as_ref()
-            .is_some_and(|c| c.health == Health::Healthy),
-        // The dependency's container has exited with status 0
-        DependsOnCondition::ServiceCompletedSuccessfully => dep
-            .oci
-            .as_ref()
-            .is_some_and(|c| c.status == ContainerStatus::Stopped && c.exit_code == Some(0)),
+        DependsOnCondition::ServiceHealthy => dep.healthy,
+        DependsOnCondition::ServiceCompletedSuccessfully => dep.completed_successfully,
     }
 }
 
@@ -354,16 +345,20 @@ mod tests {
         .unwrap()
     }
 
-    /// Build a `depends_on` of `service_started` entries with the given
+    fn svc(value: serde_json::Value) -> Service {
+        serde_json::from_value(value).unwrap()
+    }
+
+    /// Build a `depends_on` of `condition` entries with the given
     /// `(name, required)` pairs.
-    fn started_deps(entries: &[(&str, bool)]) -> DependsOn {
+    fn deps(condition: DependsOnCondition, entries: &[(&str, bool)]) -> DependsOn {
         entries
             .iter()
             .map(|(name, required)| {
                 (
                     name.to_string(),
                     DependencySpec {
-                        condition: DependsOnCondition::ServiceStarted,
+                        condition,
                         restart: false,
                         required: *required,
                     },
@@ -373,8 +368,56 @@ mod tests {
             .into()
     }
 
+    fn started_deps(entries: &[(&str, bool)]) -> DependsOn {
+        deps(DependsOnCondition::ServiceStarted, entries)
+    }
+
     fn check(device: &Device, deps: &DependsOn) -> bool {
         dependencies_satisfied(device, &"app-uuid".into(), &"rel-uuid".into(), deps)
+    }
+
+    #[test]
+    fn condition_met_started_reads_started_flag() {
+        let s = svc(json!({"id": 1, "image": "alpine:latest", "started": true, "config": {}}));
+        assert!(condition_met(&s, DependsOnCondition::ServiceStarted));
+        let s = svc(json!({"id": 1, "image": "alpine:latest", "started": false, "config": {}}));
+        assert!(!condition_met(&s, DependsOnCondition::ServiceStarted));
+    }
+
+    #[test]
+    fn condition_met_healthy_reads_healthy_flag() {
+        let s = svc(json!({"id": 1, "image": "alpine:latest", "healthy": true, "config": {}}));
+        assert!(condition_met(&s, DependsOnCondition::ServiceHealthy));
+        // default flag is false; a started-but-unconfirmed service is not healthy
+        let s = svc(json!({"id": 1, "image": "alpine:latest", "started": true, "config": {}}));
+        assert!(!condition_met(&s, DependsOnCondition::ServiceHealthy));
+    }
+
+    #[test]
+    fn condition_met_completed_reads_completed_flag() {
+        let s = svc(
+            json!({"id": 1, "image": "alpine:latest", "completed_successfully": true, "config": {}}),
+        );
+        assert!(condition_met(
+            &s,
+            DependsOnCondition::ServiceCompletedSuccessfully
+        ));
+        let s = svc(json!({"id": 1, "image": "alpine:latest", "started": true, "config": {}}));
+        assert!(!condition_met(
+            &s,
+            DependsOnCondition::ServiceCompletedSuccessfully
+        ));
+    }
+
+    #[test]
+    fn condition_met_is_specific_to_the_condition() {
+        // a healthy-confirmed service does not satisfy a completed dependency
+        let s = svc(json!({"id": 1, "image": "alpine:latest", "healthy": true, "config": {}}));
+        assert!(condition_met(&s, DependsOnCondition::ServiceHealthy));
+        assert!(!condition_met(
+            &s,
+            DependsOnCondition::ServiceCompletedSuccessfully
+        ));
     }
 
     #[test]
@@ -429,5 +472,66 @@ mod tests {
     fn missing_optional_dependency_proceeds() {
         let device = device_with(json!({}));
         assert!(check(&device, &started_deps(&[("db", false)])));
+    }
+
+    #[test]
+    fn satisfied_when_required_healthy_dependency_is_confirmed() {
+        let device = device_with(json!({
+            "db": {"id": 1, "image": "alpine:latest", "started": true, "healthy": true, "config": {}},
+        }));
+        assert!(check(
+            &device,
+            &deps(DependsOnCondition::ServiceHealthy, &[("db", true)])
+        ));
+    }
+
+    #[test]
+    fn blocks_on_unconfirmed_required_healthy_dependency() {
+        let device = device_with(json!({
+            "db": {"id": 1, "image": "alpine:latest", "started": true, "config": {}},
+        }));
+        assert!(!check(
+            &device,
+            &deps(DependsOnCondition::ServiceHealthy, &[("db", true)])
+        ));
+    }
+
+    #[test]
+    fn proceeds_on_unconfirmed_optional_healthy_dependency() {
+        let device = device_with(json!({
+            "db": {"id": 1, "image": "alpine:latest", "started": true, "config": {}},
+        }));
+        assert!(check(
+            &device,
+            &deps(DependsOnCondition::ServiceHealthy, &[("db", false)])
+        ));
+    }
+
+    #[test]
+    fn satisfied_when_required_completed_dependency_is_confirmed() {
+        let device = device_with(json!({
+            "migrate": {"id": 1, "image": "alpine:latest", "started": true, "completed_successfully": true, "config": {}},
+        }));
+        assert!(check(
+            &device,
+            &deps(
+                DependsOnCondition::ServiceCompletedSuccessfully,
+                &[("migrate", true)]
+            )
+        ));
+    }
+
+    #[test]
+    fn blocks_on_unconfirmed_required_completed_dependency() {
+        let device = device_with(json!({
+            "migrate": {"id": 1, "image": "alpine:latest", "started": true, "config": {}},
+        }));
+        assert!(!check(
+            &device,
+            &deps(
+                DependsOnCondition::ServiceCompletedSuccessfully,
+                &[("migrate", true)]
+            )
+        ));
     }
 }

--- a/helios-state/src/tasks/helpers.rs
+++ b/helios-state/src/tasks/helpers.rs
@@ -188,6 +188,7 @@ pub fn service_matches_target(
     svc.image.is_same_artifact(&t_svc.image)
         && svc.config == t_svc.config
         && svc.started == t_svc.started
+        && svc.depends_on == t_svc.depends_on
         && linked_resources_can_migrate(
             device,
             t_device,

--- a/helios-state/src/worker/tests/services.rs
+++ b/helios-state/src/worker/tests/services.rs
@@ -630,3 +630,330 @@ fn it_orders_service_start_by_depends_on() {
             + seq!("finish release 'my-release-uuid' for app with uuid 'my-app-uuid'"),
     );
 }
+
+#[test]
+fn it_awaits_health_before_starting_a_dependent() {
+    init_tracing();
+    assert_workflow(
+        json!({
+            "uuid": "my-device-uuid",
+            "apps": { "my-app-uuid": { "id": 1, "name": "my-app" } },
+        }),
+        json!({
+            "uuid": "my-device-uuid",
+            "apps": {
+                "my-app-uuid": {
+                    "id": 1,
+                    "name": "my-app",
+                    "releases": {
+                        "my-release-uuid": {
+                            "installed": true,
+                            "services": {
+                                "db": {
+                                    "id": 1,
+                                    "image": "alpine:latest",
+                                    "started": true,
+                                    "config": {},
+                                },
+                                "web": {
+                                    "id": 2,
+                                    "image": "alpine:latest",
+                                    "started": true,
+                                    "depends_on": {
+                                        "db": {"condition": "service_healthy", "restart": false, "required": true}
+                                    },
+                                    "config": {},
+                                },
+                            }
+                        }
+                    }
+                }
+            },
+        }),
+        seq!("initialize release 'my-release-uuid' for app with uuid 'my-app-uuid'")
+            + par!(
+                "initialize service 'db' for release 'my-release-uuid'",
+                "initialize service 'web' for release 'my-release-uuid'",
+            )
+            + seq!("pull image 'alpine:latest'")
+            + par!(
+                "install service 'db' for release 'my-release-uuid'",
+                "install service 'web' for release 'my-release-uuid'",
+            )
+            // db must be started and report healthy before web may start
+            + seq!(
+                "start service 'db' for release 'my-release-uuid'",
+                "await service 'db' healthy for release 'my-release-uuid'",
+                "start service 'web' for release 'my-release-uuid'",
+            )
+            + seq!("finish release 'my-release-uuid' for app with uuid 'my-app-uuid'"),
+    );
+}
+
+#[test]
+fn it_awaits_completion_before_starting_a_dependent() {
+    init_tracing();
+    assert_workflow(
+        json!({
+            "uuid": "my-device-uuid",
+            "apps": { "my-app-uuid": { "id": 1, "name": "my-app" } },
+        }),
+        json!({
+            "uuid": "my-device-uuid",
+            "apps": {
+                "my-app-uuid": {
+                    "id": 1,
+                    "name": "my-app",
+                    "releases": {
+                        "my-release-uuid": {
+                            "installed": true,
+                            "services": {
+                                "migrate": {
+                                    "id": 1,
+                                    "image": "alpine:latest",
+                                    "started": true,
+                                    "config": {},
+                                },
+                                "web": {
+                                    "id": 2,
+                                    "image": "alpine:latest",
+                                    "started": true,
+                                    "depends_on": {
+                                        "migrate": {"condition": "service_completed_successfully", "restart": false, "required": true}
+                                    },
+                                    "config": {},
+                                },
+                            }
+                        }
+                    }
+                }
+            },
+        }),
+        seq!("initialize release 'my-release-uuid' for app with uuid 'my-app-uuid'")
+            + par!(
+                "initialize service 'migrate' for release 'my-release-uuid'",
+                "initialize service 'web' for release 'my-release-uuid'",
+            )
+            + seq!("pull image 'alpine:latest'")
+            + par!(
+                "install service 'migrate' for release 'my-release-uuid'",
+                "install service 'web' for release 'my-release-uuid'",
+            )
+            // migrate must be started and exit 0 before web may start
+            + seq!(
+                "start service 'migrate' for release 'my-release-uuid'",
+                "await service 'migrate' completed for release 'my-release-uuid'",
+                "start service 'web' for release 'my-release-uuid'",
+            )
+            + seq!("finish release 'my-release-uuid' for app with uuid 'my-app-uuid'"),
+    );
+}
+
+#[test]
+fn it_emits_a_single_await_for_a_shared_healthy_dependency() {
+    init_tracing();
+    assert_workflow(
+        json!({
+            "uuid": "my-device-uuid",
+            "apps": { "my-app-uuid": { "id": 1, "name": "my-app" } },
+        }),
+        json!({
+            "uuid": "my-device-uuid",
+            "apps": {
+                "my-app-uuid": {
+                    "id": 1,
+                    "name": "my-app",
+                    "releases": {
+                        "my-release-uuid": {
+                            "installed": true,
+                            "services": {
+                                "db": {
+                                    "id": 1,
+                                    "image": "alpine:latest",
+                                    "started": true,
+                                    "config": {},
+                                },
+                                "web": {
+                                    "id": 2,
+                                    "image": "alpine:latest",
+                                    "started": true,
+                                    "depends_on": {
+                                        "db": {"condition": "service_healthy", "restart": false, "required": true}
+                                    },
+                                    "config": {},
+                                },
+                                "api": {
+                                    "id": 3,
+                                    "image": "alpine:latest",
+                                    "started": true,
+                                    "depends_on": {
+                                        "db": {"condition": "service_healthy", "restart": false, "required": true}
+                                    },
+                                    "config": {},
+                                },
+                            }
+                        }
+                    }
+                }
+            },
+        }),
+        seq!("initialize release 'my-release-uuid' for app with uuid 'my-app-uuid'")
+            + par!(
+                "initialize service 'api' for release 'my-release-uuid'",
+                "initialize service 'db' for release 'my-release-uuid'",
+                "initialize service 'web' for release 'my-release-uuid'",
+            )
+            + seq!("pull image 'alpine:latest'")
+            + par!(
+                "install service 'api' for release 'my-release-uuid'",
+                "install service 'db' for release 'my-release-uuid'",
+                "install service 'web' for release 'my-release-uuid'",
+            )
+            // a single await for the shared 'db' dependency gates both dependents
+            + seq!("start service 'db' for release 'my-release-uuid'")
+            + seq!("await service 'db' healthy for release 'my-release-uuid'")
+            + par!(
+                "start service 'api' for release 'my-release-uuid'",
+                "start service 'web' for release 'my-release-uuid'",
+            )
+            + seq!("finish release 'my-release-uuid' for app with uuid 'my-app-uuid'"),
+    );
+}
+
+#[test]
+fn it_does_not_await_an_optional_healthy_dependency() {
+    init_tracing();
+    assert_workflow(
+        json!({
+            "uuid": "my-device-uuid",
+            "apps": { "my-app-uuid": { "id": 1, "name": "my-app" } },
+        }),
+        json!({
+            "uuid": "my-device-uuid",
+            "apps": {
+                "my-app-uuid": {
+                    "id": 1,
+                    "name": "my-app",
+                    "releases": {
+                        "my-release-uuid": {
+                            "installed": true,
+                            "services": {
+                                "db": {
+                                    "id": 1,
+                                    "image": "alpine:latest",
+                                    "started": true,
+                                    "config": {},
+                                },
+                                "web": {
+                                    "id": 2,
+                                    "image": "alpine:latest",
+                                    "started": true,
+                                    "depends_on": {
+                                        "db": {"condition": "service_healthy", "restart": false, "required": false}
+                                    },
+                                    "config": {},
+                                },
+                            }
+                        }
+                    }
+                }
+            },
+        }),
+        seq!("initialize release 'my-release-uuid' for app with uuid 'my-app-uuid'")
+            + par!(
+                "initialize service 'db' for release 'my-release-uuid'",
+                "initialize service 'web' for release 'my-release-uuid'",
+            )
+            + seq!("pull image 'alpine:latest'")
+            + par!(
+                "install service 'db' for release 'my-release-uuid'",
+                "install service 'web' for release 'my-release-uuid'",
+            )
+            // optional dependency: no await is emitted and 'web' is not gated
+            + par!(
+                "start service 'db' for release 'my-release-uuid'",
+                "start service 'web' for release 'my-release-uuid'",
+            )
+            + seq!("finish release 'my-release-uuid' for app with uuid 'my-app-uuid'"),
+    );
+}
+
+#[test]
+fn it_orders_a_realistic_dependency_graph() {
+    init_tracing();
+    assert_workflow(
+        json!({
+            "uuid": "my-device-uuid",
+            "apps": { "my-app-uuid": { "id": 1, "name": "my-app" } },
+        }),
+        json!({
+            "uuid": "my-device-uuid",
+            "apps": {
+                "my-app-uuid": {
+                    "id": 1,
+                    "name": "my-app",
+                    "releases": {
+                        "my-release-uuid": {
+                            "installed": true,
+                            "services": {
+                                "db": {
+                                    "id": 1, "image": "alpine:latest", "started": true, "config": {}
+                                },
+                                "oneshot": {
+                                    "id": 2, "image": "alpine:latest", "started": true, "config": {}
+                                },
+                                "server": {
+                                    "id": 3, "image": "alpine:latest", "started": true,
+                                    "depends_on": {
+                                        "db": {"condition": "service_healthy", "restart": false, "required": true}
+                                    },
+                                    "config": {}
+                                },
+                                "client": {
+                                    "id": 4, "image": "alpine:latest", "started": true,
+                                    "depends_on": {
+                                        "db": {"condition": "service_healthy", "restart": false, "required": true},
+                                        "server": {"condition": "service_started", "restart": false, "required": true},
+                                        "oneshot": {"condition": "service_completed_successfully", "restart": false, "required": true}
+                                    },
+                                    "config": {}
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+        }),
+        // db and oneshot have no deps and start in parallel; their awaits run in
+        // parallel (a single `await db healthy`, shared by server and client);
+        // server starts after db is healthy; client starts last, gated on db
+        // healthy + server started + oneshot completed.
+        seq!("initialize release 'my-release-uuid' for app with uuid 'my-app-uuid'")
+            + par!(
+                "initialize service 'client' for release 'my-release-uuid'",
+                "initialize service 'db' for release 'my-release-uuid'",
+                "initialize service 'oneshot' for release 'my-release-uuid'",
+                "initialize service 'server' for release 'my-release-uuid'",
+            )
+            + seq!("pull image 'alpine:latest'")
+            + par!(
+                "install service 'client' for release 'my-release-uuid'",
+                "install service 'db' for release 'my-release-uuid'",
+                "install service 'oneshot' for release 'my-release-uuid'",
+                "install service 'server' for release 'my-release-uuid'",
+            )
+            + par!(
+                "start service 'db' for release 'my-release-uuid'",
+                "start service 'oneshot' for release 'my-release-uuid'",
+            )
+            + par!(
+                "await service 'db' healthy for release 'my-release-uuid'",
+                "await service 'oneshot' completed for release 'my-release-uuid'",
+            )
+            + seq!(
+                "start service 'server' for release 'my-release-uuid'",
+                "start service 'client' for release 'my-release-uuid'",
+            )
+            + seq!("finish release 'my-release-uuid' for app with uuid 'my-app-uuid'"),
+    );
+}

--- a/helios-state/src/worker/tests/services.rs
+++ b/helios-state/src/worker/tests/services.rs
@@ -571,3 +571,62 @@ fn it_finds_a_workflow_for_updating_services() {
             ),
     );
 }
+
+#[test]
+fn it_orders_service_start_by_depends_on() {
+    init_tracing();
+    assert_workflow(
+        json!({
+            "uuid": "my-device-uuid",
+            "apps": { "my-app-uuid": { "id": 1, "name": "my-app" } },
+        }),
+        json!({
+            "uuid": "my-device-uuid",
+            "apps": {
+                "my-app-uuid": {
+                    "id": 1,
+                    "name": "my-app",
+                    "releases": {
+                        "my-release-uuid": {
+                            "installed": true,
+                            "services": {
+                                "db": {
+                                    "id": 1,
+                                    "image": "alpine:latest",
+                                    "started": true,
+                                    "config": {},
+                                },
+                                "web": {
+                                    "id": 2,
+                                    "image": "alpine:latest",
+                                    "started": true,
+                                    "depends_on": {
+                                        "db": {"condition": "service_started", "restart": false, "required": true}
+                                    },
+                                    "config": {},
+                                },
+                            }
+                        }
+                    }
+                }
+            },
+        }),
+        seq!("initialize release 'my-release-uuid' for app with uuid 'my-app-uuid'")
+            + par!(
+                "initialize service 'db' for release 'my-release-uuid'",
+                "initialize service 'web' for release 'my-release-uuid'",
+            )
+            + seq!("pull image 'alpine:latest'")
+            + par!(
+                "install service 'db' for release 'my-release-uuid'",
+                "install service 'web' for release 'my-release-uuid'",
+            )
+            // The installs parallelize, but the starts are serialized indicating
+            // service_started dependency being enforced.
+            + seq!(
+                "start service 'db' for release 'my-release-uuid'",
+                "start service 'web' for release 'my-release-uuid'",
+            )
+            + seq!("finish release 'my-release-uuid' for app with uuid 'my-app-uuid'"),
+    );
+}


### PR DESCRIPTION
Change-type: minor

## Release Notes
### service_started

A dependent on two `service_started` deps: the deps start in parallel, the dependent only after both.

```
+ ~ - start service 'cache'
  ~ - start service 'db'
- start service 'web'
```

### service_healthy / service_completed_successfully

A **required** `service_healthy` / `service_completed_successfully` dep emits an `await` task; the dependent starts only once it resolves. Multiple awaits run in parallel:

```
+ ~ - await service 'db' healthy
  ~ - await service 'migrate' completed
- start service 'web'        (after both awaits resolve)
```

- A required `service_started` dep gates the start directly with no `await`.
- An **optional** (`required: false`) dep of any condition is not awaited and does not block. (Full Compose parity which involves waiting for an optional dep and warning if it fails, is deferred. see below.)

### Await logging with slow dependencies

While awaiting, the task polls the engine every 1s and logs the observed state every ~15s:

```
still awaiting (status=Running, health=Starting) task=... # service_healthy, in grace period
still awaiting (status=Running, health=None) task=... # service_completed_successfully, still running
```

`status`/`health` show why it's still waiting. Completion and duration come from mahler's own `close` task log. Deps that settle within ~15s emit no heartbeat.

### Fail-fast & recovery

A required dep that reaches a terminal failure fails the await rather than polling forever; the workflow then retries every ~30s:

```
ERROR error=dependency failed while awaiting health: unhealthy task=...
ERROR error=dependency failed while awaiting completion: exited with code 1 task=...
```

Recoverable failures are picked up on a later seek. never-satisfiable ones loop indefinitely (release abortion deferred, see below):

- **Health recovers**: a later check can flip a container back to healthy, so a dep that recovers starts its dependent on a subsequent seek.
- **Completion under `restart: on-failure` recovers, without ever erroring**: a restarting container reads as `Running` (pending), so the await just waits until it exits 0, then the dependent starts.
- **Terminal completion** (non-zero exit, `restart: no`) is never satisfiable, so fail-fasts every retry and loops.
- **`restart: always` + `service_completed_successfully`** never completes even if the dependent exited with code 0, so the dependent waits forever, also matching Compose. Whether this constitutes an aborted release is deferred.

### Release validation

An undefined reference or a dependency cycle is rejected at release deserialization, before any workflow runs, matching Docker Compose.

| input | rejection |
|---|---|
| `web → ghost` (undefined) | `service 'web' depends on undefined service 'ghost'` |
| `a → b → a` | `circular depends_on involving service 'b'` |
| `a → a` | `circular depends_on involving service 'a'` |

### Deferred to separate PRs

- **`required: false` optional-dependency parity**: Compose *waits* for an optional dependency and warns if it fails; Helios currently doesn't wait at all.
- **`restart:` propagation**: needs a Helios-driven restart action first. Similar to Compose, `restart` only covers Helios-issued restarts, not engine-driven ones.
- **Reverse stop/teardown ordering**: Compose stops dependents before dependencies which mirrors startup. `condition` doesn't apply to shutdown.
- **Runtime release abort**: a never-satisfiable condition (e.g. a non-zero exit with no restart for service_completed_successfully) retries indefinitely rather than aborting the release; deciding when to give up for cases like these is left to a follow-up.
