### PR TITLE
Normalize on-failure restart policy with no retry count

### DIFF
--- a/helios-remote-model/src/service/mod.rs
+++ b/helios-remote-model/src/service/mod.rs
@@ -247,12 +247,7 @@ mod tests {
     fn composition_with_restart_policy() {
         let comp: ServiceComposition =
             serde_json::from_value(serde_json::json!({"restart": "on-failure:5"})).unwrap();
-        assert_eq!(
-            comp.restart,
-            RestartPolicy::OnFailure {
-                max_retries: Some(5)
-            }
-        );
+        assert_eq!(comp.restart, RestartPolicy::OnFailure { max_retries: 5 });
     }
 
     #[test]

--- a/helios-remote-model/src/service/restart_policy.rs
+++ b/helios-remote-model/src/service/restart_policy.rs
@@ -10,7 +10,7 @@ pub enum RestartPolicy {
     #[default]
     Always,
     OnFailure {
-        max_retries: Option<u32>,
+        max_retries: u32,
     },
     UnlessStopped,
 }
@@ -35,12 +35,11 @@ impl std::str::FromStr for RestartPolicy {
             "unless-stopped" => Ok(Self::UnlessStopped),
             _ if s.starts_with("on-failure") => {
                 let max_retries = if let Some(rest) = s.strip_prefix("on-failure:") {
-                    Some(
-                        rest.parse::<u32>()
-                            .map_err(|e| format!("invalid max retries in '{s}': {e}"))?,
-                    )
+                    rest.parse::<u32>()
+                        .map_err(|e| format!("invalid max retries in '{s}': {e}"))?
                 } else if s == "on-failure" {
-                    None
+                    // unlimited retries
+                    0
                 } else {
                     return Err(format!("invalid restart policy: '{s}'"));
                 };
@@ -79,18 +78,13 @@ mod tests {
     #[test]
     fn restart_policy_deserialize_on_failure() {
         let rp = deser_restart(serde_json::json!("on-failure")).unwrap();
-        assert_eq!(rp, RestartPolicy::OnFailure { max_retries: None });
+        assert_eq!(rp, RestartPolicy::OnFailure { max_retries: 0 });
     }
 
     #[test]
     fn restart_policy_deserialize_on_failure_with_retries() {
         let rp = deser_restart(serde_json::json!("on-failure:3")).unwrap();
-        assert_eq!(
-            rp,
-            RestartPolicy::OnFailure {
-                max_retries: Some(3)
-            }
-        );
+        assert_eq!(rp, RestartPolicy::OnFailure { max_retries: 3 });
     }
 
     #[test]

--- a/helios-state/src/models/service/mod.rs
+++ b/helios-state/src/models/service/mod.rs
@@ -154,9 +154,9 @@ impl From<RemoteServiceTarget> for ServiceTarget {
         let restart_policy = match composition.restart {
             RemoteRestartPolicy::No => RestartPolicy::No,
             RemoteRestartPolicy::Always => RestartPolicy::Always,
-            RemoteRestartPolicy::OnFailure { max_retries } => {
-                RestartPolicy::OnFailure { max_retries }
-            }
+            RemoteRestartPolicy::OnFailure { max_retries } => RestartPolicy::OnFailure {
+                max_retries: Some(max_retries),
+            },
             RemoteRestartPolicy::UnlessStopped => RestartPolicy::UnlessStopped,
         };
 


### PR DESCRIPTION
A bare `restart: on-failure` parsed to no retry count, but the engine sets `0` by default. This mismatch meant that `restart: on-failure` could not be applied to the device. Set `on-failure` to 0 in remote model by default if no value supplised.

Change-type: patch