### PR TITLE
Make logs display name configurable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1062,6 +1062,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tracing",
+ "tracing-subscriber",
  "uuid",
  "zbus",
 ]

--- a/helios-legacy/src/takeover.rs
+++ b/helios-legacy/src/takeover.rs
@@ -1,6 +1,6 @@
 use helios_oci::Client;
 use helios_util::systemd;
-use tracing::{debug, info, warn};
+use tracing::{debug, info, instrument, warn};
 
 /// ES-module script (run via `node --input-type=module -e`) that idempotently
 /// points the legacy supervisor at helios by writing its `apiEndpointOverride`
@@ -65,6 +65,7 @@ pub enum TakeoverError {
 /// then restart it so it re-reads the override.
 ///
 /// Idempotent: a supervisor already configured for takeover is left untouched.
+#[instrument(name = "takeover", skip_all, err)]
 pub async fn takeover(oci: &Client, cfg: TakeoverConfig) -> Result<TakeoverOutcome, TakeoverError> {
     let container = oci.non_namepaced_container();
 

--- a/helios-state/src/seek.rs
+++ b/helios-state/src/seek.rs
@@ -345,7 +345,7 @@ async fn seek_target(
     Ok(UpdateStatus::Interrupted)
 }
 
-#[instrument(name = "seek", skip_all, err)]
+#[instrument(name = "state", skip_all, err)]
 pub async fn start_seek(
     runtime: Resources,
     initial_state: Device,

--- a/helios-util/Cargo.toml
+++ b/helios-util/Cargo.toml
@@ -27,6 +27,7 @@ sha2.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
 tracing.workspace = true
+tracing-subscriber.workspace = true
 uuid.workspace = true
 zbus.workspace = true
 tar.workspace = true

--- a/helios-util/src/logs.rs
+++ b/helios-util/src/logs.rs
@@ -1,4 +1,11 @@
+use std::fmt;
+
 use mahler::json::Operation;
+use tracing::{Event, Level, Subscriber};
+use tracing_subscriber::{
+    fmt::{FmtContext, FormatEvent, FormatFields, FormattedFields, format::Writer},
+    registry::{LookupSpan, Scope},
+};
 
 static SENSITIVE_KEYWORDS: &[&str] = &[
     "auth", "card", "cert", "cookie", "cred", "cvv", "cvc", "e-mail", "e_mail", "email", "key",
@@ -84,6 +91,86 @@ pub fn mask_sensitive_data(mut operation: Operation) -> Operation {
     }
 
     operation
+}
+
+/// A custom event formatter that allows to configure the outermost
+/// span in the scope via the display_name property.
+///
+/// Events will read a `<display_name>:poll:..` rather than using the crate-derived target.
+pub struct LocalEventFormatter {
+    pub display_name: String,
+}
+
+impl LocalEventFormatter {
+    /// Right-padded, optionally coloured level tag, matching the built-in
+    /// compact formatter.
+    fn write_level(&self, writer: &mut Writer<'_>, level: &Level) -> fmt::Result {
+        let (tag, color) = match *level {
+            Level::TRACE => ("TRACE", "\x1b[35m"),
+            Level::DEBUG => ("DEBUG", "\x1b[34m"),
+            Level::INFO => (" INFO", "\x1b[32m"),
+            Level::WARN => (" WARN", "\x1b[33m"),
+            Level::ERROR => ("ERROR", "\x1b[31m"),
+        };
+        if writer.has_ansi_escapes() {
+            write!(writer, "{color}{tag}\x1b[0m ")
+        } else {
+            write!(writer, "{tag} ")
+        }
+    }
+}
+
+impl<S, N> FormatEvent<S, N> for LocalEventFormatter
+where
+    S: Subscriber + for<'a> LookupSpan<'a>,
+    N: for<'a> FormatFields<'a> + 'static,
+{
+    fn format_event(
+        &self,
+        ctx: &FmtContext<'_, S, N>,
+        mut writer: Writer<'_>,
+        event: &Event<'_>,
+    ) -> fmt::Result {
+        let meta = event.metadata();
+        let ansi = writer.has_ansi_escapes();
+
+        self.write_level(&mut writer, meta.level())?;
+
+        // Service name first, then each span in the scope from the root down,
+        // joined by ':' (e.g. `helios:poll:`).
+        let bold = |name: &str| -> String {
+            if ansi {
+                format!("\x1b[1m{name}\x1b[0m:")
+            } else {
+                format!("{name}:")
+            }
+        };
+        write!(writer, "{}", bold(&self.display_name))?;
+        if let Some(scope) = ctx.event_scope() {
+            for span in scope.from_root() {
+                write!(writer, "{}", bold(span.name()))?;
+            }
+        }
+        writer.write_char(' ')?;
+
+        // Event fields (renders the `message` field as the log line).
+        ctx.format_fields(writer.by_ref(), event)?;
+
+        // Append span fields dimmed, matching the compact formatter.
+        for span in ctx.event_scope().into_iter().flat_map(Scope::from_root) {
+            let exts = span.extensions();
+            if let Some(fields) = exts.get::<FormattedFields<N>>()
+                && !fields.is_empty()
+            {
+                if ansi {
+                    write!(writer, " \x1b[2m{}\x1b[0m", fields.fields)?;
+                } else {
+                    write!(writer, " {}", fields.fields)?;
+                }
+            }
+        }
+        writeln!(writer)
+    }
 }
 
 #[cfg(test)]

--- a/helios/src/cli.rs
+++ b/helios/src/cli.rs
@@ -57,6 +57,14 @@ pub struct DaemonArgs {
     )]
     pub host_runtime_dir: Option<PathBuf>,
 
+    /// Top level service name to show on the local logs
+    #[arg(
+        env = "HELIOS_LOCAL_DISPLAY_NAME",
+        long = "local-display-name",
+        value_name = "str"
+    )]
+    pub local_display_name: Option<String>,
+
     /// Local API listen address
     #[arg(
         env = "HELIOS_LOCAL_API_ADDRESS",
@@ -64,6 +72,15 @@ pub struct DaemonArgs {
         value_name = "addr"
     )]
     pub local_api_address: Option<LocalAddress>,
+
+    /// Seek retry backoff in milliseconds
+    #[arg(
+        env = "HELIOS_LOCAL_RETRY_INTERVAL_MS",
+        long = "local-retry-interval-ms",
+        value_name = "ms",
+        value_parser = parse_duration,
+    )]
+    pub local_retry_interval: Option<Duration>,
 
     /// Remote API endpoint URI
     #[arg(
@@ -122,15 +139,6 @@ pub struct DaemonArgs {
         requires = "remote_api_endpoint"
     )]
     pub remote_poll_max_jitter: Option<Duration>,
-
-    /// Seek retry backoff in milliseconds
-    #[arg(
-        env = "HELIOS_LOCAL_RETRY_INTERVAL_MS",
-        long = "local-retry-interval-ms",
-        value_name = "ms",
-        value_parser = parse_duration,
-    )]
-    pub local_retry_interval: Option<Duration>,
 
     /// URI of legacy Supervisor API
     #[arg(
@@ -200,6 +208,14 @@ pub struct DaemonArgs {
 
 #[derive(Clone, Debug, Args)]
 pub struct TakeoverArgs {
+    /// Top level service name to show on the local logs
+    #[arg(
+        env = "HELIOS_LOCAL_DISPLAY_NAME",
+        long = "local-display-name",
+        value_name = "str"
+    )]
+    pub local_display_name: Option<String>,
+
     /// Value written verbatim to the supervisor's `apiEndpointOverride`
     #[arg(long = "override-host", value_name = "url")]
     pub host_override: String,

--- a/helios/src/main.rs
+++ b/helios/src/main.rs
@@ -4,10 +4,10 @@ use std::time::Duration;
 
 use tokio::net::{TcpListener, UnixListener};
 use tokio::sync::watch::{self};
-use tracing::{debug, info, instrument, trace, warn};
+use tracing::{debug, error, info, trace, warn};
 use tracing_subscriber::{
     EnvFilter,
-    fmt::{self, format::FmtSpan},
+    fmt::{format::FmtSpan, layer as fmt_layer},
     layer::SubscriberExt,
     util::SubscriberInitExt,
 };
@@ -21,7 +21,6 @@ use helios_remote as remote;
 use helios_state as state;
 use helios_store::DocumentStore;
 use helios_util as util;
-use helios_util::types::Uuid;
 
 use crate::api::{ApiConfig, Listener, LocalAddress};
 use crate::cli::DaemonArgs;
@@ -33,8 +32,10 @@ use crate::remote::{
 use crate::state::StateConfig;
 use crate::util::config::StoredConfig;
 use crate::util::dirs::config_dir;
+use crate::util::logs::LocalEventFormatter;
+use crate::util::types::Uuid;
 
-fn initialize_tracing() {
+fn initialize_tracing(display_name: String) {
     // Initialize tracing subscriber for human-readable logs
     tracing_subscriber::registry()
         .with(
@@ -48,20 +49,26 @@ fn initialize_tracing() {
             ),
         )
         .with(
-            fmt::layer()
-                .with_writer(std::io::stderr)
+            fmt_layer()
                 .with_span_events(FmtSpan::CLOSE)
-                .event_format(fmt::format().compact().with_target(false).without_time()),
+                .event_format(LocalEventFormatter { display_name }),
         )
         .init();
 }
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> {
-    initialize_tracing();
-
     // Dispatch on the applet selected by argv[0] (busybox-style multicall).
-    let cli = match cli::parse() {
+    let mut applet = cli::parse();
+
+    // The service name labels every log line; fall back to "helios" when unset.
+    let display_name = match &mut applet {
+        cli::Applet::Helios(args) => args.local_display_name.take(),
+        cli::Applet::HeliosLegacyTakeover(args) => args.local_display_name.take(),
+    };
+    initialize_tracing(display_name.unwrap_or_else(|| env!("CARGO_PKG_NAME").to_owned()));
+
+    let cli = match applet {
         cli::Applet::HeliosLegacyTakeover(args) => {
             let oci = oci::Client::connect().await?;
             legacy::takeover(&oci, args.into()).await?;
@@ -111,12 +118,12 @@ async fn main() -> Result<(), Box<dyn Error>> {
         legacy_config,
         retry_interval,
     )
-    .await?;
+    .await
+    .inspect_err(|err| error!("{err}"))?;
 
     Ok(())
 }
 
-#[instrument(name = "helios", skip_all, err)]
 async fn start_supervisor(
     uuid: Uuid,
     state_config: StateConfig,

--- a/helios/src/main.rs
+++ b/helios/src/main.rs
@@ -4,10 +4,10 @@ use std::time::Duration;
 
 use tokio::net::{TcpListener, UnixListener};
 use tokio::sync::watch::{self};
-use tracing::{debug, error, info, trace, warn};
+use tracing::{Level, debug, error, info, trace, warn};
 use tracing_subscriber::{
     EnvFilter,
-    fmt::{format::FmtSpan, layer as fmt_layer},
+    fmt::{format::FmtSpan, layer as fmt_layer, writer::MakeWriterExt},
     layer::SubscriberExt,
     util::SubscriberInitExt,
 };
@@ -50,6 +50,12 @@ fn initialize_tracing(display_name: String) {
         )
         .with(
             fmt_layer()
+                // INFO and below go to stdout; WARN and ERROR go to stderr.
+                .with_writer(
+                    std::io::stderr
+                        .with_max_level(Level::WARN)
+                        .or_else(std::io::stdout),
+                )
                 .with_span_events(FmtSpan::CLOSE)
                 .event_format(LocalEventFormatter { display_name }),
         )

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -56,6 +56,12 @@ if [ -n "${BALENA_HOST_RUNTIME_DIR}" ]; then
   export HELIOS_HOST_RUNTIME_DIR
 fi
 
+# Do not allow the log display name to be user configurable
+unset HELIOS_LOCAL_DISPLAY_NAME
+if [ -n "${BALENA_SERVICE_NAME}" ]; then
+  export HELIOS_LOCAL_DISPLAY_NAME="${BALENA_SERVICE_NAME}"
+fi
+
 # Run in unmanaged mode if the legacy Supervisor is unmanaged
 if [ -n "${BALENA_API_URL}" ] && [ -n "${BALENA_API_KEY}" ]; then
   HELIOS_REMOTE_API_ENDPOINT="${BALENA_API_URL}"


### PR DESCRIPTION
Logs will by default show with the name of the crate as the top level span, e.g. `helios:poll:...`. 

This PR allows the name to be configurable via the `--display-name` CLI argument. When running in a container, it uses the name in the `BALENA_SERVICE_NAME` environment variable to make sure the right name will show on the dashboard logs.

This PR also configures tracing so warn/error logs are sent to `stderr` so they are given the right priority on the systemd journal.

Depends-on: #123 