### PR TITLE
Remove logs top level span

### DIFF
--- a/helios-legacy/src/takeover.rs
+++ b/helios-legacy/src/takeover.rs
@@ -1,6 +1,6 @@
 use helios_oci::Client;
 use helios_util::systemd;
-use tracing::{debug, info, warn};
+use tracing::{debug, info, instrument, warn};
 
 /// ES-module script (run via `node --input-type=module -e`) that idempotently
 /// points the legacy supervisor at helios by writing its `apiEndpointOverride`
@@ -65,6 +65,7 @@ pub enum TakeoverError {
 /// then restart it so it re-reads the override.
 ///
 /// Idempotent: a supervisor already configured for takeover is left untouched.
+#[instrument(name = "takeover", skip_all, err)]
 pub async fn takeover(oci: &Client, cfg: TakeoverConfig) -> Result<TakeoverOutcome, TakeoverError> {
     let container = oci.non_namepaced_container();
 

--- a/helios/src/main.rs
+++ b/helios/src/main.rs
@@ -4,10 +4,10 @@ use std::time::Duration;
 
 use tokio::net::{TcpListener, UnixListener};
 use tokio::sync::watch::{self};
-use tracing::{debug, info, instrument, trace, warn};
+use tracing::{Level, debug, error, info, trace, warn};
 use tracing_subscriber::{
     EnvFilter,
-    fmt::{self, format::FmtSpan},
+    fmt::{format::FmtSpan, layer as fmt_layer, writer::MakeWriterExt},
     layer::SubscriberExt,
     util::SubscriberInitExt,
 };
@@ -48,8 +48,13 @@ fn initialize_tracing() {
             ),
         )
         .with(
-            fmt::layer()
-                .with_writer(std::io::stderr)
+            fmt_layer()
+                // INFO and below go to stdout; WARN and ERROR go to stderr.
+                .with_writer(
+                    std::io::stderr
+                        .with_max_level(Level::WARN)
+                        .or_else(std::io::stdout),
+                )
                 .with_span_events(FmtSpan::CLOSE)
                 .event_format(fmt::format().compact().with_target(false).without_time()),
         )

--- a/helios/src/main.rs
+++ b/helios/src/main.rs
@@ -4,10 +4,10 @@ use std::time::Duration;
 
 use tokio::net::{TcpListener, UnixListener};
 use tokio::sync::watch::{self};
-use tracing::{Level, debug, error, info, trace, warn};
+use tracing::{Level, debug, info, trace, warn};
 use tracing_subscriber::{
     EnvFilter,
-    fmt::{format::FmtSpan, layer as fmt_layer, writer::MakeWriterExt},
+    fmt::{self, format::FmtSpan, layer as fmt_layer, writer::MakeWriterExt},
     layer::SubscriberExt,
     util::SubscriberInitExt,
 };
@@ -121,7 +121,6 @@ async fn main() -> Result<(), Box<dyn Error>> {
     Ok(())
 }
 
-#[instrument(name = "helios", skip_all, err)]
 async fn start_supervisor(
     uuid: Uuid,
     state_config: StateConfig,


### PR DESCRIPTION
We don't want the `helios` name to show up on the logs. In places like the balena dashboard, the service name used in the composition already shows up. Just removing the `start_supervisor` instrumentation achieves this goal.

Logs. will appear on the terminal as follows

```
 INFO report: waiting for state changes
 INFO seek: waiting for target
 INFO api: ready
 INFO poll: starting
 INFO seek: applying target state
 INFO seek: no pending state changes
 INFO seek: target state applied
```

This PR also makes sure that warn/error logs are sent to `stderr` and the rest are sent to `stdout` so the logs have the correct priority on the journal

Change-type: patch 