### PR TITLE
Add compose ports support

### DIFF
--- a/helios-integration-tests/Cargo.toml
+++ b/helios-integration-tests/Cargo.toml
@@ -51,6 +51,8 @@ tokio = { version = "1.52.2", default-features = false, features = [
   "time",
   "fs",
   "sync",
+  "net",
+  "io-util",
 ] }
 tokio-stream = { version = "0.1.18", default-features = false, features = [
   "sync",

--- a/helios-integration-tests/src/api_tests.rs
+++ b/helios-integration-tests/src/api_tests.rs
@@ -1,8 +1,12 @@
+use std::time::Duration;
+
 use bollard::Docker;
 use bollard::config::RestartPolicy;
 use bollard::config::RestartPolicyNameEnum;
 use reqwest::StatusCode;
 use serde_json::{Value, json};
+use tokio::io::AsyncReadExt;
+use tokio::net::TcpStream;
 
 use super::common::{HELIOS_URL, prune_images, wait_for_target_apply};
 
@@ -130,6 +134,26 @@ fn assert_endpoint_aliases(
             "endpoint '{network_oci_name}' missing alias '{expected}'; got {aliases:?}"
         );
     }
+}
+
+/// Connect to a TCP address and read until the peer closes the connection.
+/// Retries to cover the gap between restarts of the one-shot `nc` listener.
+async fn read_from_port(addr: &str) -> String {
+    let mut last_err = None;
+    for _ in 0..5 {
+        match TcpStream::connect(addr).await {
+            Ok(mut stream) => {
+                let mut buf = String::new();
+                stream.read_to_string(&mut buf).await.unwrap();
+                if !buf.is_empty() {
+                    return buf;
+                }
+            }
+            Err(e) => last_err = Some(e),
+        }
+        tokio::time::sleep(Duration::from_millis(500)).await;
+    }
+    panic!("could not read from '{addr}'; last error: {last_err:?}")
 }
 
 async fn assert_network_created(docker: &Docker, oci_name: &str, logical_name: &str) {
@@ -270,9 +294,10 @@ async fn test_set_app_target_install_images() {
                     "id": 2,
                     "image": "alpine:latest",
                     "composition": {
-                        "command": ["sleep", "10"],
+                        "command": ["sh", "-c", "while true; do echo -n 'Hello World!!' | nc -lv -p 8080; done"],
                         "labels": { "my-label": "true" },
                         "environment": ["MY_KEY=123"],
+                        "ports": ["8080:8080"],
                         "volumes": [
                             {
                                 "type": "volume",
@@ -408,7 +433,14 @@ async fn test_set_app_target_install_images() {
         .unwrap();
     let config = container.config.unwrap();
     let host_config = container.host_config.unwrap();
-    assert_eq!(config.cmd.unwrap(), vec!["sleep", "10"]);
+    assert_eq!(
+        config.cmd.unwrap(),
+        vec![
+            "sh",
+            "-c",
+            "while true; do echo -n 'Hello World!!' | nc -lv -p 8080; done"
+        ]
+    );
     assert_eq!(
         host_config.restart_policy.unwrap(),
         RestartPolicy {
@@ -420,6 +452,25 @@ async fn test_set_app_target_install_images() {
     assert_eq!(labels.get("io.balena.app-uuid").unwrap(), TEST_APP_UUID);
     assert_eq!(labels.get("my-label").unwrap(), "true");
     assert_env_contains(&config.env.unwrap(), &["MY_KEY=123"]);
+
+    // The compose `ports` entry surfaces in the engine port bindings and in
+    // the reported service config.
+    let bindings = host_config
+        .port_bindings
+        .as_ref()
+        .and_then(|b| b.get("8080/tcp"))
+        .and_then(|b| b.as_ref())
+        .expect("no port binding for 8080/tcp");
+    assert_eq!(bindings.len(), 1);
+    assert_eq!(bindings[0].host_port.as_deref(), Some("8080"));
+    assert_eq!(
+        svc_two.get("config").and_then(|c| c.get("ports")).unwrap(),
+        &json!([{"target": 8080, "published": "8080", "protocol": "tcp"}])
+    );
+
+    // The published port binds on the docker-in-docker daemon's network
+    // namespace, reachable from the test runner at the `docker` hostname.
+    assert_eq!(read_from_port("docker:8080").await, "Hello World!!");
 
     // Three networks exist: two defined in the release plus the auto-injected `default`
     // for services without an explicit network configuration.

--- a/helios-oci/src/container.rs
+++ b/helios-oci/src/container.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{BTreeSet, HashMap};
 
 use bollard::{
     config::{
@@ -21,6 +21,7 @@ use serde::{Deserialize, Serialize};
 use tokio_stream::StreamExt;
 
 use super::datetime::DateTime;
+use super::ports::{PortMapping, from_oci_port_map, to_oci_port_maps};
 use super::util::types::{Environment, ImageUri};
 use super::{Client, Error, LocalNamespace, Namespace, NoNamespace, Result, WithContext};
 
@@ -453,6 +454,17 @@ impl<N> TryFrom<ContainerInspectResponse> for LocalContainer<N> {
         // serialized JSON, so reordering must not trigger reconfiguration.
         volumes.sort_by(|a, b| a.target().cmp(b.target()));
 
+        // Published ports round-trip through `HostConfig.PortBindings`, which
+        // holds exactly what the create request asked for. `Config.ExposedPorts`
+        // is deliberately ignored (it includes image EXPOSE entries), as is
+        // `NetworkSettings.Ports` (only populated while the container runs).
+        let ports = host_config
+            .as_mut()
+            .and_then(|hc| hc.port_bindings.take())
+            .map(from_oci_port_map)
+            .transpose()?
+            .unwrap_or_default();
+
         let mut config = value.config;
         let labels = config
             .as_mut()
@@ -543,6 +555,7 @@ impl<N> TryFrom<ContainerInspectResponse> for LocalContainer<N> {
             networks,
             network_mode,
             volumes,
+            ports,
         };
 
         let created: DateTime = value
@@ -1275,6 +1288,11 @@ pub struct ContainerConfig {
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub volumes: Vec<Mount>,
 
+    /// Published container ports. Serialized as compose short-syntax strings;
+    /// the set keeps the serialized form deterministic and deduplicated.
+    #[serde(skip_serializing_if = "BTreeSet::is_empty")]
+    pub ports: BTreeSet<PortMapping>,
+
     /// Container healthcheck. `None` means defer to the image's HEALTHCHECK
     pub healthcheck: Option<Healthcheck>,
 }
@@ -1323,6 +1341,7 @@ impl PartialEq for ContainerConfig {
                 .iter()
                 .all(|(k, v)| other.networks.get(k) == Some(v))
             && self.volumes == other.volumes
+            && self.ports == other.ports
     }
 }
 
@@ -1363,6 +1382,7 @@ impl From<ContainerConfig> for ContainerCreateBody {
             networks,
             network_mode,
             volumes,
+            ports,
         } = value;
 
         let env = if environment.is_empty() {
@@ -1423,6 +1443,13 @@ impl From<ContainerConfig> for ContainerCreateBody {
             Some(volumes.into_iter().map(Into::into).collect())
         };
 
+        let (exposed_ports, port_bindings) = if ports.is_empty() {
+            (None, None)
+        } else {
+            let (exposed, bindings) = to_oci_port_maps(ports);
+            (Some(exposed), Some(bindings))
+        };
+
         let cgroupns_mode = Some(cgroup.into());
 
         let host_config = bollard::config::HostConfig {
@@ -1446,6 +1473,7 @@ impl From<ContainerConfig> for ContainerCreateBody {
             network_mode: host_network_mode,
             oom_score_adj,
             pids_limit,
+            port_bindings,
             privileged: Some(privileged),
             readonly_rootfs: Some(read_only),
             restart_policy: Some(restart_policy),
@@ -1460,6 +1488,7 @@ impl From<ContainerConfig> for ContainerCreateBody {
             cmd,
             domainname,
             env,
+            exposed_ports,
             healthcheck: healthcheck.map(Into::into),
             hostname,
             labels: Some(labels),
@@ -1643,6 +1672,113 @@ mod tests {
         assert_eq!(hc.init, None);
         assert_eq!(hc.privileged, Some(false));
         assert_eq!(hc.readonly_rootfs, Some(false));
+    }
+
+    #[test]
+    fn container_create_body_emits_ports() {
+        let cfg = ContainerConfig {
+            ports: BTreeSet::from([
+                "8080:80".parse().unwrap(),
+                "127.0.0.1:8081:80".parse().unwrap(),
+                "53:53/udp".parse().unwrap(),
+            ]),
+            ..Default::default()
+        };
+        let body: ContainerCreateBody = cfg.into();
+        assert_eq!(
+            body.exposed_ports,
+            Some(vec!["53/udp".into(), "80/tcp".into()])
+        );
+        let bindings = body.host_config.unwrap().port_bindings.unwrap();
+        assert_eq!(
+            bindings["80/tcp"],
+            Some(vec![
+                bollard::models::PortBinding {
+                    host_ip: None,
+                    host_port: Some("8080".to_string()),
+                },
+                bollard::models::PortBinding {
+                    host_ip: Some("127.0.0.1".to_string()),
+                    host_port: Some("8081".to_string()),
+                },
+            ])
+        );
+        assert_eq!(
+            bindings["53/udp"],
+            Some(vec![bollard::models::PortBinding {
+                host_ip: None,
+                host_port: Some("53".to_string()),
+            }])
+        );
+    }
+
+    #[test]
+    fn container_create_body_omits_empty_ports() {
+        let body: ContainerCreateBody = ContainerConfig::default().into();
+        assert_eq!(body.exposed_ports, None);
+        assert_eq!(body.host_config.unwrap().port_bindings, None);
+    }
+
+    #[test]
+    fn inspect_reads_port_bindings() {
+        let resp = ContainerInspectResponse {
+            id: Some("cid".to_string()),
+            name: Some("/svc".to_string()),
+            image: Some("img".to_string()),
+            created: Some("2026-01-01T00:00:00Z".to_string()),
+            host_config: Some(HostConfig {
+                port_bindings: Some(bollard::models::PortMap::from([(
+                    "80/tcp".to_string(),
+                    Some(vec![bollard::models::PortBinding {
+                        // the engine reports unset values as empty strings
+                        host_ip: Some("".to_string()),
+                        host_port: Some("8080".to_string()),
+                    }]),
+                )])),
+                ..Default::default()
+            }),
+            state: Some(bollard::models::ContainerState {
+                status: Some(ContainerStateStatusEnum::RUNNING),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let c: LocalContainer = resp.try_into().unwrap();
+        assert_eq!(c.config.ports, BTreeSet::from(["8080:80".parse().unwrap()]));
+    }
+
+    #[test]
+    fn ports_round_trip_through_create_and_inspect() {
+        let ports: BTreeSet<PortMapping> = BTreeSet::from([
+            "8080:80".parse().unwrap(),
+            "127.0.0.1:8081:80".parse().unwrap(),
+            "53:53/udp".parse().unwrap(),
+            "443".parse().unwrap(),
+            "8000-9000:3000".parse().unwrap(),
+        ]);
+        let cfg = ContainerConfig {
+            ports: ports.clone(),
+            ..Default::default()
+        };
+        let body: ContainerCreateBody = cfg.into();
+
+        let resp = ContainerInspectResponse {
+            id: Some("cid".to_string()),
+            name: Some("/svc".to_string()),
+            image: Some("img".to_string()),
+            created: Some("2026-01-01T00:00:00Z".to_string()),
+            host_config: Some(HostConfig {
+                port_bindings: body.host_config.unwrap().port_bindings,
+                ..Default::default()
+            }),
+            state: Some(bollard::models::ContainerState {
+                status: Some(ContainerStateStatusEnum::RUNNING),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let c: LocalContainer = resp.try_into().unwrap();
+        assert_eq!(c.config.ports, ports);
     }
 
     #[test]

--- a/helios-oci/src/lib.rs
+++ b/helios-oci/src/lib.rs
@@ -20,6 +20,9 @@ pub use container::{
 mod datetime;
 pub use datetime::DateTime;
 
+mod ports;
+pub use ports::{HostPort, PortMapping, PortProtocol};
+
 mod network;
 pub use network::{
     LocalNetwork, Network, NetworkConfig, NetworkDriver, NetworkIpamConfig, NetworkIpamDriver,

--- a/helios-oci/src/ports.rs
+++ b/helios-oci/src/ports.rs
@@ -1,0 +1,431 @@
+//! Container port publishing configuration (Compose `ports`).
+//!
+//! A [`PortMapping`] holds a single container (target) port using the Compose
+//! long-syntax fields, but serializes as the canonical short-syntax string
+//! `[HOST_IP:][HOST_PORT:]CONTAINER_PORT/PROTOCOL` (protocol always explicit)
+//! so ports stay readable in serialized state. Mappings are kept in a
+//! `BTreeSet` since port order carries no meaning; the set guarantees a
+//! deterministic serialized form for state comparison.
+
+use std::collections::BTreeSet;
+use std::fmt;
+use std::str::FromStr;
+
+#[cfg(any(test, feature = "test-helpers"))]
+use std::net::IpAddr;
+
+use bollard::models::{PortBinding, PortMap};
+use serde::{Deserialize, Serialize};
+
+use super::{Error, Result};
+
+/// Transport protocol of a published port.
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord)]
+#[serde(rename_all = "snake_case")]
+pub enum PortProtocol {
+    #[default]
+    Tcp,
+    Udp,
+}
+
+impl fmt::Display for PortProtocol {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(match self {
+            Self::Tcp => "tcp",
+            Self::Udp => "udp",
+        })
+    }
+}
+
+impl FromStr for PortProtocol {
+    type Err = String;
+
+    fn from_str(s: &str) -> std::result::Result<Self, String> {
+        match s {
+            "tcp" => Ok(Self::Tcp),
+            "udp" => Ok(Self::Udp),
+            other => Err(format!("unsupported port protocol `{other}`")),
+        }
+    }
+}
+
+/// Host side of a port mapping: a fixed port, or a range from which the
+/// engine picks a free port at container start.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum HostPort {
+    Single(u16),
+    Range(u16, u16),
+}
+
+impl fmt::Display for HostPort {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Single(port) => write!(f, "{port}"),
+            Self::Range(start, end) => write!(f, "{start}-{end}"),
+        }
+    }
+}
+
+impl FromStr for HostPort {
+    type Err = String;
+
+    fn from_str(s: &str) -> std::result::Result<Self, String> {
+        match s.split_once('-') {
+            Some((start, end)) => {
+                let start = parse_port(start)?;
+                let end = parse_port(end)?;
+                if start > end {
+                    return Err(format!("invalid port range `{s}`"));
+                }
+                Ok(Self::Range(start, end))
+            }
+            None => Ok(Self::Single(parse_port(s)?)),
+        }
+    }
+}
+
+impl Serialize for HostPort {
+    fn serialize<S: serde::Serializer>(
+        &self,
+        serializer: S,
+    ) -> std::result::Result<S::Ok, S::Error> {
+        serializer.collect_str(self)
+    }
+}
+
+impl<'de> Deserialize<'de> for HostPort {
+    fn deserialize<D: serde::Deserializer<'de>>(
+        deserializer: D,
+    ) -> std::result::Result<Self, D::Error> {
+        let s = String::deserialize(deserializer)?;
+        s.parse().map_err(serde::de::Error::custom)
+    }
+}
+
+/// A single published container port.
+///
+/// Field declaration order doubles as the derived `Ord` sort key, which
+/// determines the serialized order within a config's port set.
+#[serde_with::skip_serializing_none]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct PortMapping {
+    /// Container port
+    pub target: u16,
+    /// Host port (or range). `None` publishes to an ephemeral port.
+    #[serde(default)]
+    pub published: Option<HostPort>,
+    /// Host IP to bind to. `None` binds to all interfaces.
+    #[serde(default)]
+    pub host_ip: Option<String>,
+    #[serde(default)]
+    pub protocol: PortProtocol,
+}
+
+impl PortMapping {
+    /// Engine key for the container side of the mapping, e.g. `80/tcp`.
+    fn engine_key(&self) -> String {
+        format!("{}/{}", self.target, self.protocol)
+    }
+}
+
+#[cfg(any(test, feature = "test-helpers"))]
+impl fmt::Display for PortMapping {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if let Some(ip) = &self.host_ip {
+            write!(f, "{ip}:")?;
+            if let Some(published) = &self.published {
+                write!(f, "{published}")?;
+            }
+            write!(f, ":")?;
+        } else if let Some(published) = &self.published {
+            write!(f, "{published}:")?;
+        }
+        write!(f, "{}/{}", self.target, self.protocol)
+    }
+}
+
+#[cfg(any(test, feature = "test-helpers"))]
+impl FromStr for PortMapping {
+    type Err = String;
+
+    fn from_str(s: &str) -> std::result::Result<Self, String> {
+        let (spec, protocol) = match s.rsplit_once('/') {
+            Some((spec, proto)) => (spec, proto.parse()?),
+            None => (s, PortProtocol::default()),
+        };
+
+        // Split from the right so an unbracketed IPv6 host address (which
+        // itself contains `:`) is left intact as the remainder.
+        let mut parts = spec.rsplitn(3, ':');
+        let target_part = parts.next().unwrap_or_default();
+        let published_part = parts.next();
+        let host_ip_part = parts.next();
+
+        let target = parse_port(target_part)?;
+
+        let published = match published_part {
+            None => None,
+            // an empty host port is only valid together with a host IP
+            // (`127.0.0.1::80`), meaning publish to an ephemeral port
+            Some("") if host_ip_part.is_none() => {
+                return Err(format!("invalid port mapping `{s}`"));
+            }
+            Some("") => None,
+            Some(published) => Some(published.parse()?),
+        };
+
+        let host_ip = host_ip_part.map(parse_host_ip).transpose()?;
+
+        Ok(Self {
+            target,
+            published,
+            host_ip,
+            protocol,
+        })
+    }
+}
+
+fn parse_port(s: &str) -> std::result::Result<u16, String> {
+    s.parse::<u16>()
+        .ok()
+        .filter(|port| *port != 0)
+        .ok_or_else(|| format!("invalid port number `{s}`"))
+}
+
+/// Validate a host IP, accepting bracketed IPv6 (`[::1]`) but returning the
+/// unbracketed form.
+#[cfg(any(test, feature = "test-helpers"))]
+fn parse_host_ip(s: &str) -> std::result::Result<String, String> {
+    let ip = s
+        .strip_prefix('[')
+        .and_then(|rest| rest.strip_suffix(']'))
+        .unwrap_or(s);
+    ip.parse::<IpAddr>()
+        .map_err(|_| format!("invalid host IP address `{s}`"))?;
+    Ok(ip.to_string())
+}
+
+/// Build the engine `ExposedPorts` keys and `HostConfig.PortBindings` map
+/// for a container create request. Multiple mappings of the same container
+/// port/protocol are grouped into a single binding list.
+pub(crate) fn to_oci_port_maps(ports: BTreeSet<PortMapping>) -> (Vec<String>, PortMap) {
+    let mut bindings = PortMap::new();
+    for mapping in ports {
+        bindings
+            .entry(mapping.engine_key())
+            .or_insert_with(|| Some(Vec::new()))
+            .get_or_insert_with(Vec::new)
+            .push(PortBinding {
+                host_ip: mapping.host_ip,
+                host_port: mapping.published.map(|p| p.to_string()),
+            });
+    }
+    let mut exposed: Vec<String> = bindings.keys().cloned().collect();
+    exposed.sort();
+    (exposed, bindings)
+}
+
+/// Read port mappings back from the engine's `HostConfig.PortBindings`,
+/// normalizing empty-string host IP/port (the engine's "unset") to absent.
+pub(crate) fn from_oci_port_map(map: PortMap) -> Result<BTreeSet<PortMapping>> {
+    let mut ports = BTreeSet::new();
+    for (key, bindings) in map {
+        let (target, protocol) = parse_engine_key(&key)
+            .map_err(|e| Error::other(format!("invalid engine port binding `{key}`: {e}")))?;
+
+        let bindings = bindings.unwrap_or_default();
+        if bindings.is_empty() {
+            ports.insert(PortMapping {
+                target,
+                published: None,
+                host_ip: None,
+                protocol,
+            });
+            continue;
+        }
+
+        for binding in bindings {
+            let host_ip = binding.host_ip.filter(|ip| !ip.is_empty());
+            let published = binding
+                .host_port
+                .filter(|port| !port.is_empty())
+                .map(|port| port.parse::<HostPort>())
+                .transpose()
+                .map_err(|e| Error::other(format!("invalid engine port binding `{key}`: {e}")))?;
+            ports.insert(PortMapping {
+                target,
+                published,
+                host_ip,
+                protocol,
+            });
+        }
+    }
+    Ok(ports)
+}
+
+fn parse_engine_key(key: &str) -> std::result::Result<(u16, PortProtocol), String> {
+    let (port, protocol) = match key.split_once('/') {
+        Some((port, proto)) => (port, proto.parse()?),
+        None => (key, PortProtocol::default()),
+    };
+    Ok((parse_port(port)?, protocol))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn mapping(s: &str) -> PortMapping {
+        s.parse().unwrap()
+    }
+
+    #[test]
+    fn display_round_trips_canonical_forms() {
+        for canonical in [
+            "80/tcp",
+            "8080:80/tcp",
+            "8000-9000:80/tcp",
+            "127.0.0.1:8080:80/tcp",
+            "127.0.0.1::80/tcp",
+            "6060:6060/udp",
+            "::1:8080:80/tcp",
+        ] {
+            assert_eq!(mapping(canonical).to_string(), canonical);
+        }
+    }
+
+    #[test]
+    fn parse_defaults_to_tcp() {
+        assert_eq!(
+            mapping("8080:80"),
+            PortMapping {
+                target: 80,
+                published: Some(HostPort::Single(8080)),
+                host_ip: None,
+                protocol: PortProtocol::Tcp,
+            }
+        );
+    }
+
+    #[test]
+    fn parse_bracketed_ipv6_normalizes_to_unbracketed() {
+        assert_eq!(mapping("[::1]:8080:80"), mapping("::1:8080:80"));
+        assert_eq!(mapping("[::1]:8080:80").to_string(), "::1:8080:80/tcp");
+    }
+
+    #[test]
+    fn parse_ephemeral_with_host_ip() {
+        assert_eq!(
+            mapping("127.0.0.1::80"),
+            PortMapping {
+                target: 80,
+                published: None,
+                host_ip: Some("127.0.0.1".to_string()),
+                protocol: PortProtocol::Tcp,
+            }
+        );
+    }
+
+    #[test]
+    fn parse_rejects_invalid_mappings() {
+        for invalid in [
+            "",
+            ":80",
+            "0",
+            "8080:0",
+            "65536",
+            "80/icmp",
+            "host:8080:80",
+            "9000-8000:80",
+            "[::1:8080:80",
+        ] {
+            assert!(invalid.parse::<PortMapping>().is_err(), "{invalid}");
+        }
+    }
+
+    #[test]
+    fn to_engine_port_maps_groups_by_container_port() {
+        let ports = BTreeSet::from([
+            mapping("8080:80"),
+            mapping("127.0.0.1:8081:80"),
+            mapping("53:53/udp"),
+            mapping("443"),
+        ]);
+        let (exposed, bindings) = to_oci_port_maps(ports);
+
+        assert_eq!(exposed, vec!["443/tcp", "53/udp", "80/tcp"]);
+        assert_eq!(
+            bindings["80/tcp"],
+            Some(vec![
+                PortBinding {
+                    host_ip: None,
+                    host_port: Some("8080".to_string()),
+                },
+                PortBinding {
+                    host_ip: Some("127.0.0.1".to_string()),
+                    host_port: Some("8081".to_string()),
+                },
+            ])
+        );
+        assert_eq!(
+            bindings["443/tcp"],
+            Some(vec![PortBinding {
+                host_ip: None,
+                host_port: None,
+            }])
+        );
+    }
+
+    #[test]
+    fn from_engine_port_map_normalizes_empty_strings() {
+        let map = PortMap::from([(
+            "80/tcp".to_string(),
+            Some(vec![PortBinding {
+                host_ip: Some("".to_string()),
+                host_port: Some("".to_string()),
+            }]),
+        )]);
+        assert_eq!(
+            from_oci_port_map(map).unwrap(),
+            BTreeSet::from([mapping("80")])
+        );
+    }
+
+    #[test]
+    fn from_engine_port_map_handles_missing_bindings() {
+        // some engines report a published-without-bindings entry as null
+        let map = PortMap::from([("80/udp".to_string(), None)]);
+        assert_eq!(
+            from_oci_port_map(map).unwrap(),
+            BTreeSet::from([mapping("80/udp")])
+        );
+    }
+
+    #[test]
+    fn from_engine_port_map_accepts_host_port_range() {
+        let map = PortMap::from([(
+            "80/tcp".to_string(),
+            Some(vec![PortBinding {
+                host_ip: None,
+                host_port: Some("8000-9000".to_string()),
+            }]),
+        )]);
+        assert_eq!(
+            from_oci_port_map(map).unwrap(),
+            BTreeSet::from([mapping("8000-9000:80")])
+        );
+    }
+
+    #[test]
+    fn engine_round_trip() {
+        let ports = BTreeSet::from([
+            mapping("8080:80"),
+            mapping("127.0.0.1:8081:80"),
+            mapping("53:53/udp"),
+            mapping("443"),
+            mapping("8000-9000:3000"),
+        ]);
+        let (_, bindings) = to_oci_port_maps(ports.clone());
+        assert_eq!(from_oci_port_map(bindings).unwrap(), ports);
+    }
+}

--- a/helios-remote-model/src/lib.rs
+++ b/helios-remote-model/src/lib.rs
@@ -769,6 +769,51 @@ mod tests {
     }
 
     #[test]
+    fn test_rejects_target_service_with_invalid_ports() {
+        let json = json!({
+            "name": "my-device",
+            "apps": {
+                "app-one": {
+                    "id": 1,
+                    "name": "my-app",
+                    "releases": {
+                        "c8b48659434e80a8b3adc0c5ad1e347a": {
+                            "id": 7,
+                            "services": {
+                                "main": {
+                                    "id": 3,
+                                    "image_id": 4,
+                                    "image": "registry2.balena-cloud.com/v2/8a961e0325a37441f33091743fa40a4c@sha256:0f3169ee8672222eb775b032cb3b2d06ef8eafa23a970643052bb67ac1fc5cd9",
+                                    "composition": {
+                                        "ports": [
+                                            "abc",
+                                        ]
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+            }
+
+        });
+
+        let device: Device = serde_json::from_value(json).unwrap();
+        let rejection = match device.apps.get(&Uuid::from("app-one")) {
+            Some(App::Rejected(r)) => r,
+            other => panic!("app-one should be rejected, got {other:?}"),
+        };
+        assert_eq!(
+            rejection.release,
+            Uuid::from("c8b48659434e80a8b3adc0c5ad1e347a"),
+        );
+        assert_eq!(
+            rejection.reason,
+            "services.main.composition.ports: invalid port number `abc`",
+        );
+    }
+
+    #[test]
     fn test_rejects_only_invalid_app_keeping_valid_ones() {
         let json = json!({
             "name": "my-device",

--- a/helios-remote-model/src/service/mod.rs
+++ b/helios-remote-model/src/service/mod.rs
@@ -11,6 +11,7 @@ mod command;
 mod healthcheck;
 mod network_mode;
 mod networks;
+mod ports;
 mod restart_policy;
 mod volumes;
 
@@ -19,6 +20,7 @@ pub use command::*;
 pub use healthcheck::*;
 pub use network_mode::*;
 pub use networks::*;
+pub use ports::*;
 pub use restart_policy::*;
 pub use volumes::*;
 
@@ -148,6 +150,9 @@ pub struct ServiceComposition {
 
     #[serde(default)]
     pub network_mode: Option<NetworkMode>,
+
+    #[serde(default)]
+    pub ports: Ports,
 
     #[serde(default)]
     pub volumes: VolumesConfig,
@@ -465,6 +470,44 @@ mod tests {
             Some(536870912)
         );
         assert_eq!(comp.shm_size.map(ByteSize::to_bytes), Some(67108864));
+    }
+
+    #[test]
+    fn composition_ports_default_empty() {
+        let comp: ServiceComposition = serde_json::from_value(serde_json::json!({})).unwrap();
+        assert!(comp.ports.is_empty());
+    }
+
+    #[test]
+    fn composition_ports_accept_mixed_forms() {
+        let comp: ServiceComposition = serde_json::from_value(serde_json::json!({
+            "ports": [8080, "127.0.0.1:5353:53/udp", { "target": 443, "published": 8443 }],
+        }))
+        .unwrap();
+        let ports: Vec<&PortMapping> = comp.ports.iter().collect();
+        assert_eq!(
+            ports,
+            vec![
+                &PortMapping {
+                    target: 8080,
+                    published: None,
+                    host_ip: None,
+                    protocol: PortProtocol::Tcp,
+                },
+                &PortMapping {
+                    target: 53,
+                    published: Some(HostPort::Single(5353)),
+                    host_ip: Some("127.0.0.1".to_string()),
+                    protocol: PortProtocol::Udp,
+                },
+                &PortMapping {
+                    target: 443,
+                    published: Some(HostPort::Single(8443)),
+                    host_ip: None,
+                    protocol: PortProtocol::Tcp,
+                },
+            ]
+        );
     }
 
     #[test]

--- a/helios-remote-model/src/service/ports.rs
+++ b/helios-remote-model/src/service/ports.rs
@@ -1,0 +1,663 @@
+//! Service port publishing configuration as defined by the Compose spec.
+//!
+//! The `ports` field on a service is an array of mappings, each of which is
+//! either a short-form string (`"8080:80"`, `"127.0.0.1:8080:80/udp"`), a
+//! bare port number, or a long-form object with `target`/`published`/
+//! `host_ip`/`protocol`. Port ranges are expanded into individual mappings
+//! at parse time. Swarm-only long-form fields (`mode`, `name`,
+//! `app_protocol`) are ignored.
+
+use serde::{
+    Deserialize, Deserializer,
+    de::{MapAccess, Visitor, value::MapAccessDeserializer},
+};
+use std::fmt;
+use std::net::IpAddr;
+
+/// Transport protocol of a published port.
+#[derive(Debug, Default, Clone, Copy, PartialEq)]
+pub enum PortProtocol {
+    #[default]
+    Tcp,
+    Udp,
+}
+
+impl PortProtocol {
+    fn parse(s: &str) -> Result<Self, String> {
+        match s {
+            "tcp" => Ok(Self::Tcp),
+            "udp" => Ok(Self::Udp),
+            other => Err(format!("unsupported port protocol `{other}`")),
+        }
+    }
+}
+
+/// Host side of a port mapping: a fixed port, or a range from which the
+/// engine picks a free port at container start.
+#[derive(Debug, PartialEq)]
+pub enum HostPort {
+    Single(u16),
+    Range(u16, u16),
+}
+
+/// A single published container port, after range expansion.
+#[derive(Debug, PartialEq)]
+pub struct PortMapping {
+    /// Container port
+    pub target: u16,
+    /// Host port (or range). `None` publishes to an ephemeral port.
+    pub published: Option<HostPort>,
+    /// Host IP to bind to. `None` binds to all interfaces.
+    pub host_ip: Option<String>,
+    pub protocol: PortProtocol,
+}
+
+/// Service port mapping set. Ordering carries no meaning, so mappings are
+/// canonicalized into a set, which also drops duplicates.
+#[derive(Debug, Default, PartialEq)]
+pub struct Ports(Vec<PortMapping>);
+
+impl Ports {
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    pub fn iter(&self) -> std::slice::Iter<'_, PortMapping> {
+        self.0.iter()
+    }
+}
+
+impl IntoIterator for Ports {
+    type Item = PortMapping;
+    type IntoIter = std::vec::IntoIter<PortMapping>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.into_iter()
+    }
+}
+
+/// Long-form port object used during deserialization. The swarm-only
+/// `mode`, `name` and `app_protocol` fields are intentionally not declared,
+/// so they are accepted and discarded.
+#[derive(Deserialize)]
+struct LongPort {
+    target: PortOrRange,
+    #[serde(default)]
+    published: Option<PortOrRange>,
+    #[serde(default)]
+    host_ip: Option<String>,
+    #[serde(default)]
+    protocol: Option<String>,
+}
+
+/// A port or inclusive port range (`start == end` for a single port),
+/// accepted as a number or as a `"80"`/`"8000-9000"` string.
+#[derive(Clone, Copy)]
+struct PortOrRange(u16, u16);
+
+impl PortOrRange {
+    fn len(&self) -> u32 {
+        u32::from(self.1) - u32::from(self.0) + 1
+    }
+}
+
+impl<'de> Deserialize<'de> for PortOrRange {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct PortOrRangeVisitor;
+
+        impl Visitor<'_> for PortOrRangeVisitor {
+            type Value = PortOrRange;
+
+            fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {
+                f.write_str("a port number or a `port[-port]` string")
+            }
+
+            fn visit_u64<E: serde::de::Error>(self, v: u64) -> Result<Self::Value, E> {
+                let port = port_from_number(v).map_err(E::custom)?;
+                Ok(PortOrRange(port, port))
+            }
+
+            fn visit_i64<E: serde::de::Error>(self, v: i64) -> Result<Self::Value, E> {
+                let port = u64::try_from(v)
+                    .map_err(|_| format!("invalid port number `{v}`"))
+                    .and_then(port_from_number)
+                    .map_err(E::custom)?;
+                Ok(PortOrRange(port, port))
+            }
+
+            fn visit_str<E: serde::de::Error>(self, v: &str) -> Result<Self::Value, E> {
+                parse_port_or_range(v).map_err(E::custom)
+            }
+        }
+
+        deserializer.deserialize_any(PortOrRangeVisitor)
+    }
+}
+
+enum RawPort {
+    Number(u64),
+    Short(String),
+    Long(LongPort),
+}
+
+// Custom Deserialize so that errors inside the long-form object preserve
+// their field path (e.g. `ports[0].target`)
+impl<'de> Deserialize<'de> for RawPort {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct RawPortVisitor;
+
+        impl<'de> Visitor<'de> for RawPortVisitor {
+            type Value = RawPort;
+
+            fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {
+                f.write_str("a port number, a short-form port string or a long-form port object")
+            }
+
+            fn visit_u64<E: serde::de::Error>(self, v: u64) -> Result<Self::Value, E> {
+                Ok(RawPort::Number(v))
+            }
+
+            fn visit_i64<E: serde::de::Error>(self, v: i64) -> Result<Self::Value, E> {
+                u64::try_from(v)
+                    .map(RawPort::Number)
+                    .map_err(|_| E::custom(format!("invalid port number `{v}`")))
+            }
+
+            fn visit_str<E: serde::de::Error>(self, v: &str) -> Result<Self::Value, E> {
+                Ok(RawPort::Short(v.to_string()))
+            }
+
+            fn visit_string<E: serde::de::Error>(self, v: String) -> Result<Self::Value, E> {
+                Ok(RawPort::Short(v))
+            }
+
+            fn visit_map<A: MapAccess<'de>>(self, map: A) -> Result<Self::Value, A::Error> {
+                LongPort::deserialize(MapAccessDeserializer::new(map)).map(RawPort::Long)
+            }
+        }
+
+        deserializer.deserialize_any(RawPortVisitor)
+    }
+}
+
+impl<'de> Deserialize<'de> for Ports {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let raw: Vec<RawPort> = Vec::deserialize(deserializer)?;
+        let mut ports = Vec::new();
+        for entry in raw {
+            ports.extend(parse_raw_port(entry).map_err(serde::de::Error::custom)?);
+        }
+        Ok(Ports(ports))
+    }
+}
+
+fn parse_raw_port(raw: RawPort) -> Result<Vec<PortMapping>, String> {
+    match raw {
+        RawPort::Number(n) => {
+            let port = port_from_number(n)?;
+            Ok(vec![PortMapping {
+                target: port,
+                published: None,
+                host_ip: None,
+                protocol: PortProtocol::default(),
+            }])
+        }
+        RawPort::Short(s) => parse_short(&s),
+        RawPort::Long(l) => parse_long(l),
+    }
+}
+
+/// Parse a short-form mapping `[HOST_IP:][HOST_SPEC:]CONTAINER_SPEC[/PROTOCOL]`
+/// where the port specs may be ranges.
+fn parse_short(s: &str) -> Result<Vec<PortMapping>, String> {
+    let (spec, protocol) = match s.rsplit_once('/') {
+        Some((spec, proto)) => (spec, PortProtocol::parse(proto)?),
+        None => (s, PortProtocol::default()),
+    };
+
+    // Split from the right so an unbracketed IPv6 host address (which
+    // itself contains `:`) is left intact as the remainder.
+    let mut parts = spec.rsplitn(3, ':');
+    let target_part = parts.next().unwrap_or_default();
+    let published_part = parts.next();
+    let host_ip_part = parts.next();
+
+    let target = parse_port_or_range(target_part)?;
+
+    let published = match published_part {
+        None => None,
+        // an empty host port is only valid together with a host IP
+        // (`127.0.0.1::80`), meaning publish to an ephemeral port
+        Some("") if host_ip_part.is_none() => {
+            return Err(format!("invalid port mapping `{s}`"));
+        }
+        Some("") => None,
+        Some(published) => Some(parse_port_or_range(published)?),
+    };
+
+    let host_ip = host_ip_part.map(parse_host_ip).transpose()?;
+
+    expand(target, published, host_ip, protocol)
+}
+
+fn parse_long(l: LongPort) -> Result<Vec<PortMapping>, String> {
+    let LongPort {
+        target,
+        published,
+        host_ip,
+        protocol,
+    } = l;
+
+    let protocol = protocol
+        .as_deref()
+        .map(PortProtocol::parse)
+        .transpose()?
+        .unwrap_or_default();
+    let host_ip = host_ip.as_deref().map(parse_host_ip).transpose()?;
+
+    expand(target, published, host_ip, protocol)
+}
+
+/// Expand a (possibly ranged) mapping into individual single-target-port
+/// mappings, mirroring the engine's `nat` package semantics:
+///
+/// - single target + published range: the engine picks a free host port from
+///   the range, so the range is kept as the published value
+/// - target range + published range: matched pairwise (lengths must agree)
+fn expand(
+    target: PortOrRange,
+    published: Option<PortOrRange>,
+    host_ip: Option<String>,
+    protocol: PortProtocol,
+) -> Result<Vec<PortMapping>, String> {
+    let published = match published {
+        None => {
+            return Ok((target.0..=target.1)
+                .map(|port| PortMapping {
+                    target: port,
+                    published: None,
+                    host_ip: host_ip.clone(),
+                    protocol,
+                })
+                .collect());
+        }
+        Some(published) => published,
+    };
+
+    if target.len() == 1 {
+        let published = if published.len() == 1 {
+            HostPort::Single(published.0)
+        } else {
+            HostPort::Range(published.0, published.1)
+        };
+        return Ok(vec![PortMapping {
+            target: target.0,
+            published: Some(published),
+            host_ip,
+            protocol,
+        }]);
+    }
+
+    if published.len() != target.len() {
+        return Err(format!(
+            "invalid port mapping: container range {}-{} and host range {}-{} must have the same length",
+            target.0, target.1, published.0, published.1
+        ));
+    }
+
+    Ok((target.0..=target.1)
+        .zip(published.0..=published.1)
+        .map(|(target, published)| PortMapping {
+            target,
+            published: Some(HostPort::Single(published)),
+            host_ip: host_ip.clone(),
+            protocol,
+        })
+        .collect())
+}
+
+fn port_from_number(n: u64) -> Result<u16, String> {
+    u16::try_from(n)
+        .ok()
+        .filter(|port| *port != 0)
+        .ok_or_else(|| format!("invalid port number `{n}`"))
+}
+
+fn parse_port(s: &str) -> Result<u16, String> {
+    s.parse::<u16>()
+        .ok()
+        .filter(|port| *port != 0)
+        .ok_or_else(|| format!("invalid port number `{s}`"))
+}
+
+fn parse_port_or_range(s: &str) -> Result<PortOrRange, String> {
+    match s.split_once('-') {
+        Some((start, end)) => {
+            let start = parse_port(start)?;
+            let end = parse_port(end)?;
+            if start > end {
+                return Err(format!("invalid port range `{s}`"));
+            }
+            Ok(PortOrRange(start, end))
+        }
+        None => {
+            let port = parse_port(s)?;
+            Ok(PortOrRange(port, port))
+        }
+    }
+}
+
+/// Validate a host IP, accepting bracketed IPv6 (`[::1]`) but returning the
+/// unbracketed form.
+fn parse_host_ip(s: &str) -> Result<String, String> {
+    let ip = s
+        .strip_prefix('[')
+        .and_then(|rest| rest.strip_suffix(']'))
+        .unwrap_or(s);
+    ip.parse::<IpAddr>()
+        .map_err(|_| format!("invalid host IP address `{s}`"))?;
+    Ok(ip.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn ports(value: serde_json::Value) -> Ports {
+        serde_json::from_value(value).unwrap()
+    }
+
+    fn mapping(
+        target: u16,
+        published: Option<HostPort>,
+        host_ip: Option<&str>,
+        protocol: PortProtocol,
+    ) -> PortMapping {
+        PortMapping {
+            target,
+            published,
+            host_ip: host_ip.map(str::to_string),
+            protocol,
+        }
+    }
+
+    #[test]
+    fn short_form_container_port_only() {
+        let p = ports(json!(["3000"]));
+        assert_eq!(
+            p.0,
+            Vec::from([mapping(3000, None, None, PortProtocol::Tcp)])
+        );
+    }
+
+    #[test]
+    fn number_form() {
+        assert_eq!(ports(json!([8080])), ports(json!(["8080"])));
+    }
+
+    #[test]
+    fn short_form_host_and_container() {
+        let p = ports(json!(["8080:80"]));
+        assert_eq!(
+            p.0,
+            Vec::from([mapping(
+                80,
+                Some(HostPort::Single(8080)),
+                None,
+                PortProtocol::Tcp
+            )])
+        );
+    }
+
+    #[test]
+    fn short_form_with_protocol() {
+        let p = ports(json!(["6060:6060/udp", "1234:1234/tcp"]));
+        assert_eq!(
+            p.0,
+            Vec::from([
+                mapping(6060, Some(HostPort::Single(6060)), None, PortProtocol::Udp),
+                mapping(1234, Some(HostPort::Single(1234)), None, PortProtocol::Tcp),
+            ])
+        );
+    }
+
+    #[test]
+    fn short_form_with_host_ip() {
+        let p = ports(json!(["127.0.0.1:8001:8001"]));
+        assert_eq!(
+            p.0,
+            Vec::from([mapping(
+                8001,
+                Some(HostPort::Single(8001)),
+                Some("127.0.0.1"),
+                PortProtocol::Tcp
+            )])
+        );
+    }
+
+    #[test]
+    fn short_form_ephemeral_with_host_ip() {
+        let p = ports(json!(["127.0.0.1::80"]));
+        assert_eq!(
+            p.0,
+            Vec::from([mapping(80, None, Some("127.0.0.1"), PortProtocol::Tcp)])
+        );
+    }
+
+    #[test]
+    fn short_form_ipv6_host_ip() {
+        // unbracketed and bracketed IPv6 addresses parse to the same mapping
+        assert_eq!(
+            ports(json!(["::1:8080:80"])),
+            ports(json!(["[::1]:8080:80"]))
+        );
+        let p = ports(json!(["[::1]:8080:80"]));
+        assert_eq!(
+            p.0,
+            Vec::from([mapping(
+                80,
+                Some(HostPort::Single(8080)),
+                Some("::1"),
+                PortProtocol::Tcp
+            )])
+        );
+    }
+
+    #[test]
+    fn explicit_ipv6_binding_to_all_interfaces() {
+        // unbracketed and bracketed IPv6 addresses parse to the same mapping
+        assert_eq!(ports(json!([":::8080:80"])), ports(json!(["[::]:8080:80"])));
+        let p = ports(json!([":::8080:80"]));
+        assert_eq!(
+            p.0,
+            Vec::from([mapping(
+                80,
+                Some(HostPort::Single(8080)),
+                Some("::"),
+                PortProtocol::Tcp
+            )])
+        );
+    }
+
+    #[test]
+    fn short_form_container_range_expands() {
+        let p = ports(json!(["3000-3002"]));
+        assert_eq!(
+            p.0,
+            Vec::from([
+                mapping(3000, None, None, PortProtocol::Tcp),
+                mapping(3001, None, None, PortProtocol::Tcp),
+                mapping(3002, None, None, PortProtocol::Tcp),
+            ])
+        );
+    }
+
+    #[test]
+    fn short_form_matched_ranges_expand_pairwise() {
+        let p = ports(json!(["9090-9091:8080-8081"]));
+        assert_eq!(
+            p.0,
+            Vec::from([
+                mapping(8080, Some(HostPort::Single(9090)), None, PortProtocol::Tcp),
+                mapping(8081, Some(HostPort::Single(9091)), None, PortProtocol::Tcp),
+            ])
+        );
+    }
+
+    #[test]
+    fn short_form_range_with_host_ip_expands() {
+        let p = ports(json!(["127.0.0.1:5000-5001:5000-5001"]));
+        assert_eq!(
+            p.0,
+            Vec::from([
+                mapping(
+                    5000,
+                    Some(HostPort::Single(5000)),
+                    Some("127.0.0.1"),
+                    PortProtocol::Tcp
+                ),
+                mapping(
+                    5001,
+                    Some(HostPort::Single(5001)),
+                    Some("127.0.0.1"),
+                    PortProtocol::Tcp
+                ),
+            ])
+        );
+    }
+
+    #[test]
+    fn short_form_host_range_to_single_port_kept_as_range() {
+        // the engine picks a free host port from the range at start
+        let p = ports(json!(["8000-9000:80"]));
+        assert_eq!(
+            p.0,
+            Vec::from([mapping(
+                80,
+                Some(HostPort::Range(8000, 9000)),
+                None,
+                PortProtocol::Tcp
+            )])
+        );
+    }
+
+    #[test]
+    fn long_form_full() {
+        let p = ports(json!([{
+            "target": 80,
+            "published": "8080",
+            "host_ip": "127.0.0.1",
+            "protocol": "udp"
+        }]));
+        assert_eq!(
+            p.0,
+            Vec::from([mapping(
+                80,
+                Some(HostPort::Single(8080)),
+                Some("127.0.0.1"),
+                PortProtocol::Udp
+            )])
+        );
+    }
+
+    #[test]
+    fn long_form_defaults() {
+        let p = ports(json!([{ "target": 80 }]));
+        assert_eq!(p.0, Vec::from([mapping(80, None, None, PortProtocol::Tcp)]));
+    }
+
+    #[test]
+    fn long_form_published_range() {
+        let p = ports(json!([{ "target": 80, "published": "8000-9000" }]));
+        assert_eq!(
+            p.0,
+            Vec::from([mapping(
+                80,
+                Some(HostPort::Range(8000, 9000)),
+                None,
+                PortProtocol::Tcp
+            )])
+        );
+    }
+
+    #[test]
+    fn long_form_target_range_expands() {
+        let p = ports(json!([{ "target": "80-81", "published": "8080-8081" }]));
+        assert_eq!(
+            p.0,
+            Vec::from([
+                mapping(80, Some(HostPort::Single(8080)), None, PortProtocol::Tcp),
+                mapping(81, Some(HostPort::Single(8081)), None, PortProtocol::Tcp),
+            ])
+        );
+    }
+
+    #[test]
+    fn long_form_ignores_swarm_fields() {
+        let p = ports(json!([{
+            "target": 80,
+            "published": 8080,
+            "mode": "ingress",
+            "name": "web",
+            "app_protocol": "http"
+        }]));
+        assert_eq!(
+            p.0,
+            Vec::from([mapping(
+                80,
+                Some(HostPort::Single(8080)),
+                None,
+                PortProtocol::Tcp
+            )])
+        );
+    }
+
+    #[test]
+    fn rejects_invalid_mappings() {
+        for invalid in [
+            json!(["0"]),
+            json!([0]),
+            json!(["65536"]),
+            json!(["8080:0"]),
+            json!(["80/icmp"]),
+            json!(["9000-8000:80"]),
+            json!(["8080-8081:80-82"]),
+            json!(["host:8080:80"]),
+            json!(["127.0.0.1:8080"]),
+            json!([":::8080"]),
+            json!([":80"]),
+            json!([""]),
+            json!([{ "target": 80, "protocol": "icmp" }]),
+            json!([{ "target": "80-82", "published": "8080-8081" }]),
+            json!([{ "target": 80, "host_ip": "not-an-ip" }]),
+            json!([{ "published": 8080 }]),
+        ] {
+            assert!(
+                serde_json::from_value::<Ports>(invalid.clone()).is_err(),
+                "{invalid}"
+            );
+        }
+    }
+
+    #[test]
+    fn rejects_mismatched_range_lengths_with_message() {
+        let err = serde_json::from_value::<Ports>(json!(["8080-8081:80-82"])).unwrap_err();
+        assert!(err.to_string().contains("must have the same length"));
+    }
+
+    #[test]
+    fn empty_default() {
+        let p = ports(json!([]));
+        assert!(p.is_empty());
+    }
+}

--- a/helios-state/src/models/service/config.rs
+++ b/helios-state/src/models/service/config.rs
@@ -443,6 +443,40 @@ mod tests {
     }
 
     #[test]
+    fn preserves_ports_across_round_trip() {
+        let original = oci::ContainerConfig {
+            ports: ["8080:80", "127.0.0.1:5353:53/udp", "443"]
+                .into_iter()
+                .map(|p| p.parse().unwrap())
+                .collect(),
+            ..Default::default()
+        };
+        let svc = ServiceConfig(original.clone());
+        let with_labels = svc.into_oci_config(1, "svc", &make_uuid());
+
+        let back = ServiceConfig::from(with_labels);
+        assert_eq!(back.ports, original.ports);
+    }
+
+    #[test]
+    fn keeps_ports_without_tracking_label() {
+        // Ports need no entry in LABEL_CONFIG_FIELDS: `HostConfig.PortBindings`
+        // only ever contains what the create request asked for (image EXPOSE
+        // entries surface in `Config.ExposedPorts`, which is never read back).
+        let labels = HashMap::from([(LABEL_CONFIG_FIELDS.to_string(), "[]".to_string())]);
+        let inspected = oci::ContainerConfig {
+            ports: ["8080:80".parse().unwrap()].into_iter().collect(),
+            labels,
+            ..Default::default()
+        };
+        let svc = ServiceConfig::from(inspected);
+        assert_eq!(
+            svc.ports,
+            ["8080:80".parse().unwrap()].into_iter().collect()
+        );
+    }
+
+    #[test]
     fn drops_engine_inherited_healthcheck_subfields() {
         let original = oci::ContainerConfig {
             healthcheck: Some(oci::Healthcheck {

--- a/helios-state/src/models/service/mod.rs
+++ b/helios-state/src/models/service/mod.rs
@@ -2,13 +2,16 @@ use mahler::state::State;
 use serde::{Deserialize, Serialize};
 
 use crate::labels::LABEL_SERVICE_ID;
+use std::collections::BTreeSet;
+
 use crate::oci::{
-    self, BindPropagation, Cgroup, ContainerConfig, DateTime, Healthcheck, LocalContainer, Mount,
-    NetworkMode, NetworkSettings, RestartPolicy,
+    self, BindPropagation, Cgroup, ContainerConfig, DateTime, Healthcheck, HostPort,
+    LocalContainer, Mount, NetworkMode, NetworkSettings, PortMapping, PortProtocol, RestartPolicy,
 };
 use crate::remote_model::{
     BindPropagation as RemoteBindPropagation, ByteSize, Cgroup as RemoteCgroup, DurationMicros,
-    DurationNanos, DurationSecs, Mount as RemoteMount, NetworkMode as RemoteNetworkMode,
+    DurationNanos, DurationSecs, HostPort as RemoteHostPort, Mount as RemoteMount,
+    NetworkMode as RemoteNetworkMode, PortProtocol as RemotePortProtocol,
     RestartPolicy as RemoteRestartPolicy, Service as RemoteServiceTarget,
 };
 
@@ -225,6 +228,25 @@ impl From<RemoteServiceTarget> for ServiceTarget {
             })
             .collect();
 
+        // Convert the published ports. Both sides are sets ordered by the
+        // same key, so the conversion preserves the canonical form.
+        let ports: BTreeSet<PortMapping> = composition
+            .ports
+            .into_iter()
+            .map(|p| PortMapping {
+                target: p.target,
+                published: p.published.map(|hp| match hp {
+                    RemoteHostPort::Single(port) => HostPort::Single(port),
+                    RemoteHostPort::Range(start, end) => HostPort::Range(start, end),
+                }),
+                host_ip: p.host_ip,
+                protocol: match p.protocol {
+                    RemotePortProtocol::Tcp => PortProtocol::Tcp,
+                    RemotePortProtocol::Udp => PortProtocol::Udp,
+                },
+            })
+            .collect();
+
         ServiceTarget {
             id,
             image: image.into(),
@@ -286,6 +308,7 @@ impl From<RemoteServiceTarget> for ServiceTarget {
                 networks,
                 network_mode,
                 volumes,
+                ports,
                 healthcheck: composition.healthcheck.and_then(|h| {
                     // If healthcheck: {}, collapse to None to allow
                     // the service to inherit the image's HEALTHCHECK


### PR DESCRIPTION
Add support for [service.ports](https://github.com/compose-spec/compose-spec/blob/main/05-services.md#ports) as part of the composition. Both long and short syntax are supported

Internally, the port mapping is stored in long form, to account for future expansions of the specification. 

Change-type: patch