### PR TITLE
Add support for compose service.entrypoint

### DIFF
--- a/helios-oci/src/container.rs
+++ b/helios-oci/src/container.rs
@@ -492,6 +492,7 @@ impl<N> TryFrom<ContainerInspectResponse> for LocalContainer<N> {
             .as_mut()
             .and_then(|c| c.domainname.take())
             .filter(|s| !s.is_empty());
+        let entrypoint = config.as_mut().and_then(|c| c.entrypoint.take());
         let healthcheck = config
             .as_mut()
             .and_then(|c| c.healthcheck.take())
@@ -536,6 +537,7 @@ impl<N> TryFrom<ContainerInspectResponse> for LocalContainer<N> {
             cgroup,
             cgroup_parent,
             command: cmd,
+            entrypoint,
             cpuset,
             cpu_rt_period,
             cpu_rt_runtime,
@@ -1222,6 +1224,10 @@ pub struct ContainerConfig {
     /// NIS domain name to use for the container.
     pub domainname: Option<String>,
 
+    /// Entrypoint to run specified as an array of strings, overrides the
+    /// image ENTRYPOINT
+    pub entrypoint: Option<Vec<String>>,
+
     /// Environment variables
     #[serde(skip_serializing_if = "Environment::is_empty")]
     pub environment: Environment,
@@ -1330,6 +1336,7 @@ impl From<ContainerConfig> for ContainerCreateBody {
             cgroup,
             cgroup_parent,
             command: cmd,
+            entrypoint,
             cpuset,
             cpu_rt_period,
             cpu_rt_runtime,
@@ -1472,6 +1479,7 @@ impl From<ContainerConfig> for ContainerCreateBody {
         ContainerCreateBody {
             cmd,
             domainname,
+            entrypoint,
             env,
             exposed_ports,
             healthcheck: healthcheck.map(Into::into),

--- a/helios-remote-model/src/lib.rs
+++ b/helios-remote-model/src/lib.rs
@@ -534,6 +534,49 @@ mod tests {
     }
 
     #[test]
+    fn test_rejects_target_service_with_invalid_entrypoint() {
+        let json = json!({
+            "name": "my-device",
+            "apps": {
+                "app-one": {
+                    "id": 1,
+                    "name": "my-app",
+                    "releases": {
+                        "c8b48659434e80a8b3adc0c5ad1e347a": {
+                            "id": 7,
+                            "services": {
+                                "main": {
+                                    "id": 3,
+                                    "image_id": 4,
+                                    "image": "registry2.balena-cloud.com/v2/8a961e0325a37441f33091743fa40a4c@sha256:0f3169ee8672222eb775b032cb3b2d06ef8eafa23a970643052bb67ac1fc5cd9",
+                                    "composition": {
+                                        "entrypoint": "/bin/sh -c 'echo hello",
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+            }
+
+        });
+
+        let device: Device = serde_json::from_value(json).unwrap();
+        let rejection = match device.apps.get(&Uuid::from("app-one")) {
+            Some(App::Rejected(r)) => r,
+            other => panic!("app-one should be rejected, got {other:?}"),
+        };
+        assert_eq!(
+            rejection.release,
+            Uuid::from("c8b48659434e80a8b3adc0c5ad1e347a"),
+        );
+        assert_eq!(
+            rejection.reason,
+            "services.main.composition.entrypoint: missing closing quote",
+        );
+    }
+
+    #[test]
     fn test_rejects_target_service_with_invalid_networks() {
         let json = json!({
             "name": "my-device",

--- a/helios-remote-model/src/service/mod.rs
+++ b/helios-remote-model/src/service/mod.rs
@@ -89,6 +89,9 @@ pub struct ServiceComposition {
     pub domainname: Option<String>,
 
     #[serde(default)]
+    pub entrypoint: Option<Command>,
+
+    #[serde(default)]
     pub environment: Environment,
 
     #[serde(default)]
@@ -279,6 +282,26 @@ mod tests {
         let comp: ServiceComposition =
             serde_json::from_value(serde_json::json!({"stop_grace_period": 30})).unwrap();
         assert_eq!(comp.stop_grace_period.map(DurationSecs::to_i64), Some(30));
+    }
+
+    #[test]
+    fn composition_parses_entrypoint_string() {
+        let comp: ServiceComposition =
+            serde_json::from_value(serde_json::json!({"entrypoint": "/bin/sh -c"})).unwrap();
+        assert_eq!(
+            comp.entrypoint.as_deref(),
+            Some(&vec!["/bin/sh".to_string(), "-c".to_string()])
+        );
+    }
+
+    #[test]
+    fn composition_parses_entrypoint_list() {
+        let comp: ServiceComposition =
+            serde_json::from_value(serde_json::json!({"entrypoint": ["/bin/sh", "-c"]})).unwrap();
+        assert_eq!(
+            comp.entrypoint.as_deref(),
+            Some(&vec!["/bin/sh".to_string(), "-c".to_string()])
+        );
     }
 
     #[test]

--- a/helios-state/src/models/service/config.rs
+++ b/helios-state/src/models/service/config.rs
@@ -54,6 +54,7 @@ macro_rules! impl_field_tracking {
 impl_field_tracking!(oci::ContainerConfig {
     cgroup_parent,
     command,
+    entrypoint,
     healthcheck,
     hostname,
     init,
@@ -350,6 +351,7 @@ mod tests {
             cpu_rt_runtime: 950_000,
             cpu_shares: 2048,
             domainname: Some("example.com".to_string()),
+            entrypoint: Some(vec!["/entrypoint.sh".to_string()]),
             healthcheck: Some(oci::Healthcheck {
                 test: Some(vec!["CMD".to_string(), "true".to_string()]),
                 interval: Some(30_000_000_000),
@@ -379,6 +381,7 @@ mod tests {
 
         let back = ServiceConfig::from(with_labels);
         assert_eq!(back.command, original.command);
+        assert_eq!(back.entrypoint, original.entrypoint);
         assert_eq!(back.cgroup, original.cgroup);
         assert_eq!(back.cgroup_parent, original.cgroup_parent);
         assert_eq!(back.cpuset, original.cpuset);
@@ -412,6 +415,7 @@ mod tests {
         let labels = HashMap::from([(LABEL_CONFIG_FIELDS.to_string(), "[]".to_string())]);
         let inspected = oci::ContainerConfig {
             command: Some(vec!["/bin/sh".to_string()]),
+            entrypoint: Some(vec!["/docker-entrypoint.sh".to_string()]),
             healthcheck: Some(oci::Healthcheck {
                 test: Some(vec!["CMD".to_string(), "image-default".to_string()]),
                 ..Default::default()
@@ -430,6 +434,7 @@ mod tests {
         };
         let svc = ServiceConfig::from(inspected);
         assert_eq!(svc.command, None);
+        assert_eq!(svc.entrypoint, None);
         assert_eq!(svc.healthcheck, None);
         assert_eq!(svc.hostname, None);
         assert_eq!(svc.init, None);

--- a/helios-state/src/models/service/mod.rs
+++ b/helios-state/src/models/service/mod.rs
@@ -150,8 +150,9 @@ impl From<RemoteServiceTarget> for ServiceTarget {
             .chain(environment)
             .collect();
 
-        // convert the composition command to a Vec
+        // convert the composition command and entrypoint to a Vec
         let command = composition.command.map(|cmd| cmd.into_iter().collect());
+        let entrypoint = composition.entrypoint.map(|e| e.into_iter().collect());
 
         // convert the restart policy
         let restart_policy = match composition.restart {
@@ -275,6 +276,7 @@ impl From<RemoteServiceTarget> for ServiceTarget {
                 dns_opt: composition.dns_opt.unwrap_or_default(),
                 dns_search: composition.dns_search.unwrap_or_default(),
                 domainname: composition.domainname,
+                entrypoint,
                 environment,
                 extra_hosts: composition.extra_hosts.unwrap_or_default(),
                 hostname: composition.hostname,

--- a/helios-state/src/worker/tests/services.rs
+++ b/helios-state/src/worker/tests/services.rs
@@ -131,7 +131,8 @@ fn it_finds_a_workflow_to_reconfigure_a_service() {
                                     "started": true,
                                     "oci": running_container("old_container"),
                                     "config": {
-                                        "command": ["sleep", "infinity"]
+                                        "command": ["sleep", "infinity"],
+                                        "entrypoint": ["/bin/sh", "-c"]
                                     },
                                 },
                             }
@@ -161,7 +162,8 @@ fn it_finds_a_workflow_to_reconfigure_a_service() {
                                     "image": "ubuntu:latest",
                                     "started": true,
                                     "config": {
-                                        "command": ["sleep", "10"]
+                                        "command": ["sleep", "10"],
+                                        "entrypoint": ["/bin/bash", "-c"]
                                     },
                                 },
                             }


### PR DESCRIPTION
Re-uses `Command` utility type to parse the entrypoint and passes the entrypoint to the engine in accordance with the spec. Empty entrypoint (`[]` or `''`) overrides the image defined entrypoint.

Change-type: patch
Depends-on: #131 