### PR TITLE
Add support for compose security related properties

### DIFF
--- a/helios-integration-tests/src/api_tests.rs
+++ b/helios-integration-tests/src/api_tests.rs
@@ -327,6 +327,12 @@ async fn test_set_app_target_install_images() {
                     "composition": {
                         "command": ["sleep", "infinity"],
                         "network_mode": "host",
+                        // Mixed `:` and `=` separators to exercise normalization;
+                        // both must reach the engine using `=`.
+                        "security_opt": [
+                            "no-new-privileges:true",
+                            "seccomp=unconfined",
+                        ],
                     }
                 }),
             ),
@@ -519,6 +525,26 @@ async fn test_set_app_target_install_images() {
     );
     assert_container_networks(&svc_three_container, &["host"]);
 
+    // service-three's security options round-trip to the engine with the `:`
+    // separator normalized to `=`, and are reported back verbatim.
+    let svc_three_security_opt = svc_three_container
+        .host_config
+        .as_ref()
+        .and_then(|hc| hc.security_opt.as_ref())
+        .expect("host_config.security_opt not set");
+    assert!(
+        svc_three_security_opt
+            .iter()
+            .any(|o| o == "no-new-privileges=true"),
+        "expected normalized `no-new-privileges=true`; got {svc_three_security_opt:?}"
+    );
+    assert!(
+        svc_three_security_opt
+            .iter()
+            .any(|o| o == "seccomp=unconfined"),
+        "expected `seccomp=unconfined`; got {svc_three_security_opt:?}"
+    );
+
     let my_vol_id = get_resource_oci_name(app, release_uuid, "volumes", "my-vol").to_string();
     let volume = docker.inspect_volume(&my_vol_id).await.unwrap();
     assert_eq!(
@@ -610,6 +636,49 @@ async fn test_set_app_target_rejects_bind_mount_not_in_allowlist() {
     );
 
     // Confirm no app was created.
+    let res = client
+        .get(format!("{HELIOS_URL}/v3/device/apps/{TEST_APP_UUID}"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn test_set_app_target_rejects_disallowed_security_opt() {
+    let release_uuid = "reject-security-opt-release";
+    let release = release_json(
+        &[(
+            "bad-svc",
+            json!({
+                "id": 1,
+                "image": "alpine:latest",
+                "composition": {
+                    "security_opt": ["label:user:USER"]
+                }
+            }),
+        )],
+        &[],
+        &[],
+    );
+    let target = app_target_json("reject-security-opt-app", release_uuid, release);
+
+    let client = reqwest::Client::new();
+    let res = client
+        .post(format!("{HELIOS_URL}/v3/device/apps/{TEST_APP_UUID}"))
+        .json(&target)
+        .send()
+        .await
+        .unwrap();
+
+    // The remote-model allowlist check fires during deserialization, so Axum
+    // rejects the body with a 4xx before any app is created.
+    assert!(
+        res.status().is_client_error(),
+        "expected 4xx, got {}",
+        res.status()
+    );
+
     let res = client
         .get(format!("{HELIOS_URL}/v3/device/apps/{TEST_APP_UUID}"))
         .send()

--- a/helios-integration-tests/src/api_tests.rs
+++ b/helios-integration-tests/src/api_tests.rs
@@ -298,6 +298,9 @@ async fn test_set_app_target_install_images() {
                         "labels": { "my-label": "true" },
                         "environment": ["MY_KEY=123"],
                         "ports": ["8080:8080"],
+                        // Map form with a numeric value; must be coerced to a
+                        // string and reach the engine.
+                        "sysctls": { "net.ipv4.ip_forward": 1 },
                         "volumes": [
                             {
                                 "type": "volume",
@@ -458,6 +461,18 @@ async fn test_set_app_target_install_images() {
     assert_eq!(labels.get("io.balena.app-uuid").unwrap(), TEST_APP_UUID);
     assert_eq!(labels.get("my-label").unwrap(), "true");
     assert_env_contains(&config.env.unwrap(), &["MY_KEY=123"]);
+
+    // The compose `sysctls` map reaches the engine with its numeric value
+    // coerced to a string.
+    let svc_two_sysctls = host_config
+        .sysctls
+        .as_ref()
+        .expect("host_config.sysctls not set");
+    assert_eq!(
+        svc_two_sysctls.get("net.ipv4.ip_forward").map(String::as_str),
+        Some("1"),
+        "expected `net.ipv4.ip_forward=1`; got {svc_two_sysctls:?}"
+    );
 
     // The compose `ports` entry surfaces in the engine port bindings and in
     // the reported service config.
@@ -662,6 +677,49 @@ async fn test_set_app_target_rejects_disallowed_security_opt() {
         &[],
     );
     let target = app_target_json("reject-security-opt-app", release_uuid, release);
+
+    let client = reqwest::Client::new();
+    let res = client
+        .post(format!("{HELIOS_URL}/v3/device/apps/{TEST_APP_UUID}"))
+        .json(&target)
+        .send()
+        .await
+        .unwrap();
+
+    // The remote-model allowlist check fires during deserialization, so Axum
+    // rejects the body with a 4xx before any app is created.
+    assert!(
+        res.status().is_client_error(),
+        "expected 4xx, got {}",
+        res.status()
+    );
+
+    let res = client
+        .get(format!("{HELIOS_URL}/v3/device/apps/{TEST_APP_UUID}"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn test_set_app_target_rejects_non_namespaced_sysctl() {
+    let release_uuid = "reject-sysctl-release";
+    let release = release_json(
+        &[(
+            "bad-svc",
+            json!({
+                "id": 1,
+                "image": "alpine:latest",
+                "composition": {
+                    "sysctls": ["kernel.hostname=evil"]
+                }
+            }),
+        )],
+        &[],
+        &[],
+    );
+    let target = app_target_json("reject-sysctl-app", release_uuid, release);
 
     let client = reqwest::Client::new();
     let res = client

--- a/helios-integration-tests/src/bin/mock-remote.rs
+++ b/helios-integration-tests/src/bin/mock-remote.rs
@@ -116,12 +116,12 @@ async fn get_reports(State(state): State<AppState>) -> impl IntoResponse {
     drop(state);
 
     // Replay current accumulated state, then stream new reports as NDJSON
-    let replay: Option<Result<Vec<u8>, std::io::Error>> =
-        if current.as_object().unwrap().is_empty() {
-            None
-        } else {
-            Some(Ok(to_ndjson_line(&current)))
-        };
+    let replay: Option<Result<Vec<u8>, std::io::Error>> = if current.as_object().unwrap().is_empty()
+    {
+        None
+    } else {
+        Some(Ok(to_ndjson_line(&current)))
+    };
 
     let live = BroadcastStream::new(rx).filter_map(|r| r.ok().map(|v| Ok(to_ndjson_line(&v))));
     let stream = tokio_stream::iter(replay).chain(live);

--- a/helios-integration-tests/src/common.rs
+++ b/helios-integration-tests/src/common.rs
@@ -1,9 +1,9 @@
 use std::collections::HashMap;
 
 use bollard::{Docker, query_parameters::PruneImagesOptions};
-use tokio_stream::StreamExt;
 use serde_json::Value;
 use std::time::Duration;
+use tokio_stream::StreamExt;
 
 pub const HELIOS_URL: &str = "http://helios-api";
 pub const MOCK_REMOTE_URL: &str = "http://mock-remote";
@@ -73,8 +73,7 @@ pub async fn wait_for_report(
                 };
 
                 if let Some(device) = report.as_object().and_then(|m| m.values().next())
-                    && let Some(status) =
-                        device.pointer(&status_path).and_then(|s| s.as_str())
+                    && let Some(status) = device.pointer(&status_path).and_then(|s| s.as_str())
                     && status == expected_status
                 {
                     return device.pointer(&release_path).unwrap().clone();

--- a/helios-oci/src/container.rs
+++ b/helios-oci/src/container.rs
@@ -390,6 +390,10 @@ impl<N> TryFrom<ContainerInspectResponse> for LocalContainer<N> {
                     .map(|(host, ip)| (host.to_string(), ip.to_string()))
             })
             .collect::<HashMap<_, _>>();
+        let sysctls = host_config
+            .as_mut()
+            .and_then(|hc| hc.sysctls.take())
+            .unwrap_or_default();
         let init = host_config.as_mut().and_then(|hc| hc.init.take());
         // Only recognize `none`/`host` from host_config: for user networks Docker also
         // populates `network_mode` with the first network name, which would otherwise
@@ -563,6 +567,7 @@ impl<N> TryFrom<ContainerInspectResponse> for LocalContainer<N> {
             domainname,
             environment,
             extra_hosts,
+            sysctls,
             healthcheck,
             hostname,
             init,
@@ -1335,6 +1340,11 @@ pub struct ContainerConfig {
     #[serde(skip_serializing_if = "HashMap::is_empty")]
     pub extra_hosts: HashMap<String, String>,
 
+    /// Kernel parameters (sysctls) to set in the container, as a
+    /// parameter -> value map.
+    #[serde(skip_serializing_if = "HashMap::is_empty")]
+    pub sysctls: HashMap<String, String>,
+
     /// Network endpoint configurations, ordered by connection priority.
     ///
     /// Mutually exclusive with `network_mode`.
@@ -1377,6 +1387,7 @@ impl From<ContainerConfig> for ContainerCreateBody {
             domainname,
             environment,
             extra_hosts,
+            sysctls,
             healthcheck,
             hostname,
             init,
@@ -1490,6 +1501,7 @@ impl From<ContainerConfig> for ContainerCreateBody {
                     .map(|(host, ip)| format!("{host}:{ip}"))
                     .collect()
             }),
+            sysctls: (!sysctls.is_empty()).then_some(sysctls),
             init,
             memory: non_zero(mem_limit),
             memory_reservation: non_zero(mem_reservation),
@@ -2011,6 +2023,57 @@ mod tests {
         // An empty map should not emit an ExtraHosts entry on the engine request
         let empty: ContainerCreateBody = ContainerConfig::default().into();
         assert_eq!(empty.host_config.unwrap().extra_hosts, None);
+    }
+
+    #[test]
+    fn inspect_reads_sysctls() {
+        let resp = ContainerInspectResponse {
+            id: Some("cid".to_string()),
+            name: Some("/svc".to_string()),
+            image: Some("img".to_string()),
+            created: Some("2026-01-01T00:00:00Z".to_string()),
+            host_config: Some(HostConfig {
+                sysctls: Some(HashMap::from([
+                    ("net.core.somaxconn".to_string(), "1024".to_string()),
+                    ("net.ipv4.tcp_syncookies".to_string(), "0".to_string()),
+                ])),
+                ..Default::default()
+            }),
+            state: Some(bollard::models::ContainerState {
+                status: Some(ContainerStateStatusEnum::RUNNING),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let c: LocalContainer = resp.try_into().unwrap();
+        assert_eq!(
+            c.config.sysctls,
+            HashMap::from([
+                ("net.core.somaxconn".to_string(), "1024".to_string()),
+                ("net.ipv4.tcp_syncookies".to_string(), "0".to_string()),
+            ])
+        );
+    }
+
+    #[test]
+    fn container_create_body_emits_sysctls() {
+        let cfg = ContainerConfig {
+            sysctls: HashMap::from([("net.core.somaxconn".to_string(), "1024".to_string())]),
+            ..Default::default()
+        };
+        let body: ContainerCreateBody = cfg.into();
+        let hc = body.host_config.unwrap();
+        assert_eq!(
+            hc.sysctls,
+            Some(HashMap::from([(
+                "net.core.somaxconn".to_string(),
+                "1024".to_string()
+            )]))
+        );
+
+        // An empty map should not emit a Sysctls entry on the engine request
+        let empty: ContainerCreateBody = ContainerConfig::default().into();
+        assert_eq!(empty.host_config.unwrap().sysctls, None);
     }
 
     #[test]

--- a/helios-oci/src/container.rs
+++ b/helios-oci/src/container.rs
@@ -361,6 +361,10 @@ impl<N> TryFrom<ContainerInspectResponse> for LocalContainer<N> {
             .as_mut()
             .and_then(|hc| hc.cap_drop.take())
             .unwrap_or_default();
+        let group_add = host_config
+            .as_mut()
+            .and_then(|hc| hc.group_add.take())
+            .unwrap_or_default();
         let security_opt = host_config
             .as_mut()
             .and_then(|hc| hc.security_opt.take())
@@ -560,6 +564,7 @@ impl<N> TryFrom<ContainerInspectResponse> for LocalContainer<N> {
             cpu_shares,
             cap_add,
             cap_drop,
+            group_add,
             security_opt,
             dns,
             dns_opt,
@@ -1237,6 +1242,10 @@ pub struct ContainerConfig {
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub cap_drop: Vec<String>,
 
+    /// Additional groups (by name or GID) the container user is a member of.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub group_add: Vec<String>,
+
     /// Security options applied to the container.
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub security_opt: Vec<String>,
@@ -1380,6 +1389,7 @@ impl From<ContainerConfig> for ContainerCreateBody {
             cpu_shares,
             cap_add,
             cap_drop,
+            group_add,
             security_opt,
             dns,
             dns_opt,
@@ -1491,6 +1501,7 @@ impl From<ContainerConfig> for ContainerCreateBody {
             cpu_shares: non_zero(cpu_shares),
             cap_add: (!cap_add.is_empty()).then_some(cap_add),
             cap_drop: (!cap_drop.is_empty()).then_some(cap_drop),
+            group_add: (!group_add.is_empty()).then_some(group_add),
             security_opt: (!security_opt.is_empty()).then_some(security_opt),
             dns: (!dns.is_empty()).then_some(dns),
             dns_options: (!dns_opt.is_empty()).then_some(dns_opt),
@@ -2178,6 +2189,48 @@ mod tests {
         let hc = empty.host_config.unwrap();
         assert_eq!(hc.cap_add, None);
         assert_eq!(hc.cap_drop, None);
+    }
+
+    #[test]
+    fn inspect_reads_group_add() {
+        let resp = ContainerInspectResponse {
+            id: Some("cid".to_string()),
+            name: Some("/svc".to_string()),
+            image: Some("img".to_string()),
+            created: Some("2026-01-01T00:00:00Z".to_string()),
+            host_config: Some(HostConfig {
+                group_add: Some(vec!["mail".to_string(), "1000".to_string()]),
+                ..Default::default()
+            }),
+            state: Some(bollard::models::ContainerState {
+                status: Some(ContainerStateStatusEnum::RUNNING),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let c: LocalContainer = resp.try_into().unwrap();
+        assert_eq!(
+            c.config.group_add,
+            vec!["mail".to_string(), "1000".to_string()]
+        );
+    }
+
+    #[test]
+    fn container_create_body_emits_group_add() {
+        let cfg = ContainerConfig {
+            group_add: vec!["mail".to_string(), "1000".to_string()],
+            ..Default::default()
+        };
+        let body: ContainerCreateBody = cfg.into();
+        let hc = body.host_config.unwrap();
+        assert_eq!(
+            hc.group_add,
+            Some(vec!["mail".to_string(), "1000".to_string()])
+        );
+
+        // Empty list should not emit GroupAdd on the engine request
+        let empty: ContainerCreateBody = ContainerConfig::default().into();
+        assert_eq!(empty.host_config.unwrap().group_add, None);
     }
 
     #[test]

--- a/helios-oci/src/container.rs
+++ b/helios-oci/src/container.rs
@@ -353,6 +353,14 @@ impl<N> TryFrom<ContainerInspectResponse> for LocalContainer<N> {
             .as_mut()
             .and_then(|hc| hc.cpu_shares.take())
             .unwrap_or(0);
+        let cap_add = host_config
+            .as_mut()
+            .and_then(|hc| hc.cap_add.take())
+            .unwrap_or_default();
+        let cap_drop = host_config
+            .as_mut()
+            .and_then(|hc| hc.cap_drop.take())
+            .unwrap_or_default();
         let dns = host_config
             .as_mut()
             .and_then(|hc| hc.dns.take())
@@ -542,6 +550,8 @@ impl<N> TryFrom<ContainerInspectResponse> for LocalContainer<N> {
             cpu_rt_period,
             cpu_rt_runtime,
             cpu_shares,
+            cap_add,
+            cap_drop,
             dns,
             dns_opt,
             dns_search,
@@ -1209,6 +1219,14 @@ pub struct ContainerConfig {
     #[serde(skip_serializing_if = "is_zero")]
     pub cpu_shares: i64,
 
+    /// Linux capabilities to add to the container.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub cap_add: Vec<String>,
+
+    /// Linux capabilities to drop from the container.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub cap_drop: Vec<String>,
+
     /// Custom DNS servers for the container.
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub dns: Vec<String>,
@@ -1341,6 +1359,8 @@ impl From<ContainerConfig> for ContainerCreateBody {
             cpu_rt_period,
             cpu_rt_runtime,
             cpu_shares,
+            cap_add,
+            cap_drop,
             dns,
             dns_opt,
             dns_search,
@@ -1448,6 +1468,8 @@ impl From<ContainerConfig> for ContainerCreateBody {
             cpu_realtime_period: non_zero(cpu_rt_period),
             cpu_realtime_runtime: non_zero(cpu_rt_runtime),
             cpu_shares: non_zero(cpu_shares),
+            cap_add: (!cap_add.is_empty()).then_some(cap_add),
+            cap_drop: (!cap_drop.is_empty()).then_some(cap_drop),
             dns: (!dns.is_empty()).then_some(dns),
             dns_options: (!dns_opt.is_empty()).then_some(dns_opt),
             dns_search: (!dns_search.is_empty()).then_some(dns_search),
@@ -2034,6 +2056,54 @@ mod tests {
         assert_eq!(hc.dns, None);
         assert_eq!(hc.dns_options, None);
         assert_eq!(hc.dns_search, None);
+    }
+
+    #[test]
+    fn inspect_reads_cap_config() {
+        let resp = ContainerInspectResponse {
+            id: Some("cid".to_string()),
+            name: Some("/svc".to_string()),
+            image: Some("img".to_string()),
+            created: Some("2026-01-01T00:00:00Z".to_string()),
+            host_config: Some(HostConfig {
+                cap_add: Some(vec!["ALL".to_string()]),
+                cap_drop: Some(vec!["NET_ADMIN".to_string(), "SYS_ADMIN".to_string()]),
+                ..Default::default()
+            }),
+            state: Some(bollard::models::ContainerState {
+                status: Some(ContainerStateStatusEnum::RUNNING),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let c: LocalContainer = resp.try_into().unwrap();
+        assert_eq!(c.config.cap_add, vec!["ALL".to_string()]);
+        assert_eq!(
+            c.config.cap_drop,
+            vec!["NET_ADMIN".to_string(), "SYS_ADMIN".to_string()]
+        );
+    }
+
+    #[test]
+    fn container_create_body_emits_cap_config() {
+        let cfg = ContainerConfig {
+            cap_add: vec!["ALL".to_string()],
+            cap_drop: vec!["NET_ADMIN".to_string(), "SYS_ADMIN".to_string()],
+            ..Default::default()
+        };
+        let body: ContainerCreateBody = cfg.into();
+        let hc = body.host_config.unwrap();
+        assert_eq!(hc.cap_add, Some(vec!["ALL".to_string()]));
+        assert_eq!(
+            hc.cap_drop,
+            Some(vec!["NET_ADMIN".to_string(), "SYS_ADMIN".to_string()])
+        );
+
+        // Empty lists should not emit CapAdd/CapDrop on the engine request
+        let empty: ContainerCreateBody = ContainerConfig::default().into();
+        let hc = empty.host_config.unwrap();
+        assert_eq!(hc.cap_add, None);
+        assert_eq!(hc.cap_drop, None);
     }
 
     #[test]

--- a/helios-oci/src/container.rs
+++ b/helios-oci/src/container.rs
@@ -361,6 +361,10 @@ impl<N> TryFrom<ContainerInspectResponse> for LocalContainer<N> {
             .as_mut()
             .and_then(|hc| hc.cap_drop.take())
             .unwrap_or_default();
+        let security_opt = host_config
+            .as_mut()
+            .and_then(|hc| hc.security_opt.take())
+            .unwrap_or_default();
         let dns = host_config
             .as_mut()
             .and_then(|hc| hc.dns.take())
@@ -552,6 +556,7 @@ impl<N> TryFrom<ContainerInspectResponse> for LocalContainer<N> {
             cpu_shares,
             cap_add,
             cap_drop,
+            security_opt,
             dns,
             dns_opt,
             dns_search,
@@ -1227,6 +1232,10 @@ pub struct ContainerConfig {
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub cap_drop: Vec<String>,
 
+    /// Security options applied to the container.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub security_opt: Vec<String>,
+
     /// Custom DNS servers for the container.
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub dns: Vec<String>,
@@ -1361,6 +1370,7 @@ impl From<ContainerConfig> for ContainerCreateBody {
             cpu_shares,
             cap_add,
             cap_drop,
+            security_opt,
             dns,
             dns_opt,
             dns_search,
@@ -1470,6 +1480,7 @@ impl From<ContainerConfig> for ContainerCreateBody {
             cpu_shares: non_zero(cpu_shares),
             cap_add: (!cap_add.is_empty()).then_some(cap_add),
             cap_drop: (!cap_drop.is_empty()).then_some(cap_drop),
+            security_opt: (!security_opt.is_empty()).then_some(security_opt),
             dns: (!dns.is_empty()).then_some(dns),
             dns_options: (!dns_opt.is_empty()).then_some(dns_opt),
             dns_search: (!dns_search.is_empty()).then_some(dns_search),
@@ -2104,6 +2115,55 @@ mod tests {
         let hc = empty.host_config.unwrap();
         assert_eq!(hc.cap_add, None);
         assert_eq!(hc.cap_drop, None);
+    }
+
+    #[test]
+    fn inspect_reads_security_opt() {
+        let resp = ContainerInspectResponse {
+            id: Some("cid".to_string()),
+            name: Some("/svc".to_string()),
+            image: Some("img".to_string()),
+            created: Some("2026-01-01T00:00:00Z".to_string()),
+            host_config: Some(HostConfig {
+                security_opt: Some(vec![
+                    "no-new-privileges=true".to_string(),
+                    "seccomp=unconfined".to_string(),
+                ]),
+                ..Default::default()
+            }),
+            state: Some(bollard::models::ContainerState {
+                status: Some(ContainerStateStatusEnum::RUNNING),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let c: LocalContainer = resp.try_into().unwrap();
+        assert_eq!(
+            c.config.security_opt,
+            vec![
+                "no-new-privileges=true".to_string(),
+                "seccomp=unconfined".to_string()
+            ]
+        );
+    }
+
+    #[test]
+    fn container_create_body_emits_security_opt() {
+        let cfg = ContainerConfig {
+            security_opt: vec!["apparmor=unconfined".to_string()],
+            ..Default::default()
+        };
+        let body: ContainerCreateBody = cfg.into();
+        let hc = body.host_config.unwrap();
+        assert_eq!(
+            hc.security_opt,
+            Some(vec!["apparmor=unconfined".to_string()])
+        );
+
+        // An empty list should not emit SecurityOpt on the engine request
+        let empty: ContainerCreateBody = ContainerConfig::default().into();
+        let hc = empty.host_config.unwrap();
+        assert_eq!(hc.security_opt, None);
     }
 
     #[test]

--- a/helios-remote-model/src/lib.rs
+++ b/helios-remote-model/src/lib.rs
@@ -577,6 +577,49 @@ mod tests {
     }
 
     #[test]
+    fn test_rejects_target_service_with_invalid_security_opt() {
+        let json = json!({
+            "name": "my-device",
+            "apps": {
+                "app-one": {
+                    "id": 1,
+                    "name": "my-app",
+                    "releases": {
+                        "c8b48659434e80a8b3adc0c5ad1e347a": {
+                            "id": 7,
+                            "services": {
+                                "main": {
+                                    "id": 3,
+                                    "image_id": 4,
+                                    "image": "registry2.balena-cloud.com/v2/8a961e0325a37441f33091743fa40a4c@sha256:0f3169ee8672222eb775b032cb3b2d06ef8eafa23a970643052bb67ac1fc5cd9",
+                                    "composition": {
+                                        "security_opt": ["label:user:USER"]
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+            }
+
+        });
+
+        let device: Device = serde_json::from_value(json).unwrap();
+        let rejection = match device.apps.get(&Uuid::from("app-one")) {
+            Some(App::Rejected(r)) => r,
+            other => panic!("app-one should be rejected, got {other:?}"),
+        };
+        assert_eq!(
+            rejection.release,
+            Uuid::from("c8b48659434e80a8b3adc0c5ad1e347a"),
+        );
+        assert_eq!(
+            rejection.reason,
+            "services.main.composition.security_opt: only `no-new-privileges`, `apparmor=unconfined` and `seccomp=unconfined` are allowed, got `label:user:USER`",
+        );
+    }
+
+    #[test]
     fn test_rejects_target_service_with_invalid_networks() {
         let json = json!({
             "name": "my-device",

--- a/helios-remote-model/src/lib.rs
+++ b/helios-remote-model/src/lib.rs
@@ -620,6 +620,49 @@ mod tests {
     }
 
     #[test]
+    fn test_rejects_target_service_with_non_namespaced_sysctl() {
+        let json = json!({
+            "name": "my-device",
+            "apps": {
+                "app-one": {
+                    "id": 1,
+                    "name": "my-app",
+                    "releases": {
+                        "c8b48659434e80a8b3adc0c5ad1e347a": {
+                            "id": 7,
+                            "services": {
+                                "main": {
+                                    "id": 3,
+                                    "image_id": 4,
+                                    "image": "registry2.balena-cloud.com/v2/8a961e0325a37441f33091743fa40a4c@sha256:0f3169ee8672222eb775b032cb3b2d06ef8eafa23a970643052bb67ac1fc5cd9",
+                                    "composition": {
+                                        "sysctls": ["kernel.hostname=evil"]
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+            }
+
+        });
+
+        let device: Device = serde_json::from_value(json).unwrap();
+        let rejection = match device.apps.get(&Uuid::from("app-one")) {
+            Some(App::Rejected(r)) => r,
+            other => panic!("app-one should be rejected, got {other:?}"),
+        };
+        assert_eq!(
+            rejection.release,
+            Uuid::from("c8b48659434e80a8b3adc0c5ad1e347a"),
+        );
+        assert_eq!(
+            rejection.reason,
+            "services.main.composition.sysctls: only kernel-namespaced sysctls (`net.*`, `fs.mqueue.*`, `kernel.shm*`, `kernel.msg*`, `kernel.sem`) are allowed, got `kernel.hostname`",
+        );
+    }
+
+    #[test]
     fn test_rejects_target_service_with_invalid_networks() {
         let json = json!({
             "name": "my-device",

--- a/helios-remote-model/src/service/mod.rs
+++ b/helios-remote-model/src/service/mod.rs
@@ -45,6 +45,14 @@ pub struct Service {
 // FIXME: add remaining fields
 #[derive(Deserialize, Debug, Default)]
 pub struct ServiceComposition {
+    /// Linux capabilities to add to the container.
+    #[serde(default)]
+    pub cap_add: Option<Vec<String>>,
+
+    /// Linux capabilities to drop from the container.
+    #[serde(default)]
+    pub cap_drop: Option<Vec<String>>,
+
     #[serde(default)]
     pub cgroup: Option<Cgroup>,
 
@@ -653,6 +661,27 @@ mod tests {
                 "dc1.example.com".to_string(),
                 "dc2.example.com".to_string()
             ])
+        );
+    }
+
+    #[test]
+    fn composition_cap_default_unset() {
+        let comp: ServiceComposition = serde_json::from_value(serde_json::json!({})).unwrap();
+        assert_eq!(comp.cap_add, None);
+        assert_eq!(comp.cap_drop, None);
+    }
+
+    #[test]
+    fn composition_cap_accepts_list() {
+        let comp: ServiceComposition = serde_json::from_value(serde_json::json!({
+            "cap_add": ["ALL"],
+            "cap_drop": ["NET_ADMIN", "SYS_ADMIN"],
+        }))
+        .unwrap();
+        assert_eq!(comp.cap_add, Some(vec!["ALL".to_string()]));
+        assert_eq!(
+            comp.cap_drop,
+            Some(vec!["NET_ADMIN".to_string(), "SYS_ADMIN".to_string()])
         );
     }
 

--- a/helios-remote-model/src/service/mod.rs
+++ b/helios-remote-model/src/service/mod.rs
@@ -53,6 +53,11 @@ pub struct ServiceComposition {
     #[serde(default)]
     pub cap_drop: Option<Vec<String>>,
 
+    /// Additional groups, by name or GID, the container user must be a member
+    /// of. Numeric entries are accepted and coerced to strings.
+    #[serde(default, deserialize_with = "deserialize_group_add")]
+    pub group_add: Option<Vec<String>>,
+
     #[serde(default)]
     pub cgroup: Option<Cgroup>,
 
@@ -380,6 +385,34 @@ where
     }
 
     Ok(Some(map))
+}
+
+/// Deserialize Compose `group_add` from a list whose entries may be group names
+/// (strings) or GIDs (numbers), coercing numeric entries to strings.
+fn deserialize_group_add<'de, D>(deserializer: D) -> Result<Option<Vec<String>>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    #[derive(Deserialize)]
+    #[serde(untagged)]
+    enum Group {
+        Int(i64),
+        String(String),
+    }
+
+    let Some(raw) = Option::<Vec<Group>>::deserialize(deserializer)? else {
+        return Ok(None);
+    };
+
+    let groups = raw
+        .into_iter()
+        .map(|group| match group {
+            Group::String(s) => s,
+            Group::Int(i) => i.to_string(),
+        })
+        .collect();
+
+    Ok(Some(groups))
 }
 
 #[cfg(test)]
@@ -858,6 +891,26 @@ mod tests {
         assert_eq!(
             comp.cap_drop,
             Some(vec!["NET_ADMIN".to_string(), "SYS_ADMIN".to_string()])
+        );
+    }
+
+    #[test]
+    fn composition_group_add_default_unset() {
+        let comp: ServiceComposition = serde_json::from_value(serde_json::json!({})).unwrap();
+        assert_eq!(comp.group_add, None);
+    }
+
+    #[test]
+    fn composition_group_add_accepts_names_and_coerces_gids() {
+        // Entries may be group names (strings) or numeric GIDs; numbers are
+        // coerced to strings.
+        let comp: ServiceComposition = serde_json::from_value(serde_json::json!({
+            "group_add": ["mail", 1000],
+        }))
+        .unwrap();
+        assert_eq!(
+            comp.group_add,
+            Some(vec!["mail".to_string(), "1000".to_string()])
         );
     }
 

--- a/helios-remote-model/src/service/mod.rs
+++ b/helios-remote-model/src/service/mod.rs
@@ -173,6 +173,10 @@ pub struct ServiceComposition {
     #[serde(default, deserialize_with = "deserialize_extra_hosts")]
     pub extra_hosts: Option<HashMap<String, String>>,
 
+    /// Kernel parameters (sysctls) to set in the container. Only kernel-namespaced values are permitted.
+    #[serde(default, deserialize_with = "deserialize_sysctls")]
+    pub sysctls: Option<HashMap<String, String>>,
+
     #[serde(default)]
     pub pids_limit: Option<i64>,
 
@@ -298,6 +302,82 @@ where
             })
             .collect::<Result<_, D::Error>>()?,
     };
+
+    Ok(Some(map))
+}
+
+/// Validate kernel namespaces.
+///
+/// See https://docs.docker.com/reference/cli/docker/container/run/#sysctl
+fn is_namespaced_sysctl(key: &str) -> bool {
+    key.starts_with("net.")
+        || key.starts_with("fs.mqueue.")
+        || key.starts_with("kernel.shm")
+        || key.starts_with("kernel.msg")
+        || key == "kernel.sem"
+}
+
+/// Deserialize Compose `sysctls` from a list of `key=value` strings or a
+/// `key: value` mapping into a parameter -> value map. Numeric map values are
+/// accepted and coerced to strings. Only kernel-namespaced keys are allowed.
+fn deserialize_sysctls<'de, D>(deserializer: D) -> Result<Option<HashMap<String, String>>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    #[derive(Deserialize)]
+    #[serde(untagged)]
+    enum ScalarValue {
+        Int(i64),
+        Float(f64),
+        Bool(bool),
+        String(String),
+    }
+
+    impl std::fmt::Display for ScalarValue {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                ScalarValue::String(s) => write!(f, "{s}"),
+                ScalarValue::Int(i) => write!(f, "{i}"),
+                ScalarValue::Float(n) => write!(f, "{n}"),
+                ScalarValue::Bool(b) => write!(f, "{b}"),
+            }
+        }
+    }
+
+    #[derive(Deserialize)]
+    #[serde(untagged)]
+    enum Sysctls {
+        List(Vec<String>),
+        Map(HashMap<String, ScalarValue>),
+    }
+
+    let Some(raw) = Option::<Sysctls>::deserialize(deserializer)? else {
+        return Ok(None);
+    };
+
+    let map: HashMap<String, String> = match raw {
+        Sysctls::Map(map) => map
+            .into_iter()
+            .map(|(key, value)| (key, value.to_string()))
+            .collect(),
+        Sysctls::List(entries) => entries
+            .into_iter()
+            .map(|entry| {
+                let (key, value) = entry.split_once('=').ok_or_else(|| {
+                    serde::de::Error::custom(format!("entry `{entry}` must be in `key=value` form"))
+                })?;
+                Ok((key.to_string(), value.to_string()))
+            })
+            .collect::<Result<_, D::Error>>()?,
+    };
+
+    for key in map.keys() {
+        if !is_namespaced_sysctl(key) {
+            return Err(serde::de::Error::custom(format!(
+                "only kernel-namespaced sysctls (`net.*`, `fs.mqueue.*`, `kernel.shm*`, `kernel.msg*`, `kernel.sem`) are allowed, got `{key}`"
+            )));
+        }
+    }
 
     Ok(Some(map))
 }
@@ -652,6 +732,68 @@ mod tests {
         }))
         .unwrap_err();
         assert!(err.to_string().contains("host:ip"), "{err}");
+    }
+
+    #[test]
+    fn composition_sysctls_default_unset() {
+        let comp: ServiceComposition = serde_json::from_value(serde_json::json!({})).unwrap();
+        assert_eq!(comp.sysctls, None);
+    }
+
+    #[test]
+    fn composition_sysctls_accepts_list() {
+        let comp: ServiceComposition = serde_json::from_value(serde_json::json!({
+            "sysctls": ["net.core.somaxconn=1024", "net.ipv4.tcp_syncookies=0"],
+        }))
+        .unwrap();
+        assert_eq!(
+            comp.sysctls,
+            Some(HashMap::from([
+                ("net.core.somaxconn".to_string(), "1024".to_string()),
+                ("net.ipv4.tcp_syncookies".to_string(), "0".to_string()),
+            ]))
+        );
+    }
+
+    #[test]
+    fn composition_sysctls_accepts_mapping_and_coerces_numbers() {
+        // Map values may arrive as numbers; they are coerced to strings.
+        let comp: ServiceComposition = serde_json::from_value(serde_json::json!({
+            "sysctls": {"net.core.somaxconn": 1024, "net.ipv4.tcp_syncookies": "0"},
+        }))
+        .unwrap();
+        assert_eq!(
+            comp.sysctls,
+            Some(HashMap::from([
+                ("net.core.somaxconn".to_string(), "1024".to_string()),
+                ("net.ipv4.tcp_syncookies".to_string(), "0".to_string()),
+            ]))
+        );
+    }
+
+    #[test]
+    fn composition_sysctls_rejects_non_namespaced() {
+        // Both list and map forms reject keys outside the namespaced allowlist.
+        let err = serde_json::from_value::<ServiceComposition>(serde_json::json!({
+            "sysctls": ["kernel.hostname=evil"],
+        }))
+        .unwrap_err();
+        assert!(err.to_string().contains("kernel-namespaced"), "{err}");
+
+        let err = serde_json::from_value::<ServiceComposition>(serde_json::json!({
+            "sysctls": {"vm.swappiness": "10"},
+        }))
+        .unwrap_err();
+        assert!(err.to_string().contains("kernel-namespaced"), "{err}");
+    }
+
+    #[test]
+    fn composition_sysctls_rejects_list_entry_without_separator() {
+        let err = serde_json::from_value::<ServiceComposition>(serde_json::json!({
+            "sysctls": ["net.core.somaxconn"],
+        }))
+        .unwrap_err();
+        assert!(err.to_string().contains("key=value"), "{err}");
     }
 
     #[test]

--- a/helios-remote-model/src/service/mod.rs
+++ b/helios-remote-model/src/service/mod.rs
@@ -127,6 +127,11 @@ pub struct ServiceComposition {
     #[serde(default)]
     pub read_only: bool,
 
+    /// Container security options. Only `no-new-privileges`,
+    /// `apparmor=unconfined` and `seccomp=unconfined` are permitted.
+    #[serde(default, deserialize_with = "deserialize_security_opt")]
+    pub security_opt: Option<Vec<String>>,
+
     #[serde(default)]
     pub restart: RestartPolicy,
 
@@ -204,6 +209,35 @@ where
 {
     Option::<f64>::deserialize(deserializer)?
         .map(validate_cpus)
+        .transpose()
+        .map_err(serde::de::Error::custom)
+}
+
+/// Validate a single `security_opt` entry against the permitted allowlist,
+/// replacing `:` for `=` to match what the docker engine expects internally.
+fn normalize_security_opt(opt: String) -> Result<String, String> {
+    let normalized = opt.replacen(':', "=", 1);
+    match normalized.as_str() {
+        "no-new-privileges"
+        | "no-new-privileges=true"
+        | "apparmor=unconfined"
+        | "seccomp=unconfined" => Ok(normalized),
+        _ => Err(format!(
+            "only `no-new-privileges`, `apparmor=unconfined` and `seccomp=unconfined` are allowed, got `{opt}`"
+        )),
+    }
+}
+
+fn deserialize_security_opt<'de, D>(deserializer: D) -> Result<Option<Vec<String>>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    Option::<Vec<String>>::deserialize(deserializer)?
+        .map(|opts| {
+            opts.into_iter()
+                .map(normalize_security_opt)
+                .collect::<Result<Vec<_>, _>>()
+        })
         .transpose()
         .map_err(serde::de::Error::custom)
 }
@@ -683,6 +717,50 @@ mod tests {
             comp.cap_drop,
             Some(vec!["NET_ADMIN".to_string(), "SYS_ADMIN".to_string()])
         );
+    }
+
+    #[test]
+    fn composition_security_opt_default_unset() {
+        let comp: ServiceComposition = serde_json::from_value(serde_json::json!({})).unwrap();
+        assert_eq!(comp.security_opt, None);
+    }
+
+    #[test]
+    fn composition_security_opt_accepts_allowed_and_normalizes() {
+        // `:` and `=` separators are both accepted and stored with `=`.
+        let comp: ServiceComposition = serde_json::from_value(serde_json::json!({
+            "security_opt": [
+                "no-new-privileges",
+                "no-new-privileges:true",
+                "apparmor:unconfined",
+                "seccomp=unconfined",
+            ],
+        }))
+        .unwrap();
+        assert_eq!(
+            comp.security_opt,
+            Some(vec![
+                "no-new-privileges".to_string(),
+                "no-new-privileges=true".to_string(),
+                "apparmor=unconfined".to_string(),
+                "seccomp=unconfined".to_string(),
+            ])
+        );
+    }
+
+    #[test]
+    fn composition_security_opt_rejects_disallowed() {
+        for value in [
+            "label:user:USER",
+            "apparmor=custom",
+            "seccomp=/profile.json",
+            "no-new-privileges=false",
+        ] {
+            let _ = serde_json::from_value::<ServiceComposition>(serde_json::json!({
+                "security_opt": [value],
+            }))
+            .unwrap_err();
+        }
     }
 
     #[test]

--- a/helios-state/src/models/service/mod.rs
+++ b/helios-state/src/models/service/mod.rs
@@ -272,6 +272,8 @@ impl From<RemoteServiceTarget> for ServiceTarget {
                     .map(DurationMicros::to_i64)
                     .unwrap_or(0),
                 cpu_shares: composition.cpu_shares.unwrap_or(0),
+                cap_add: composition.cap_add.unwrap_or_default(),
+                cap_drop: composition.cap_drop.unwrap_or_default(),
                 dns: composition.dns.unwrap_or_default(),
                 dns_opt: composition.dns_opt.unwrap_or_default(),
                 dns_search: composition.dns_search.unwrap_or_default(),

--- a/helios-state/src/models/service/mod.rs
+++ b/helios-state/src/models/service/mod.rs
@@ -274,6 +274,7 @@ impl From<RemoteServiceTarget> for ServiceTarget {
                 cpu_shares: composition.cpu_shares.unwrap_or(0),
                 cap_add: composition.cap_add.unwrap_or_default(),
                 cap_drop: composition.cap_drop.unwrap_or_default(),
+                security_opt: composition.security_opt.unwrap_or_default(),
                 dns: composition.dns.unwrap_or_default(),
                 dns_opt: composition.dns_opt.unwrap_or_default(),
                 dns_search: composition.dns_search.unwrap_or_default(),

--- a/helios-state/src/models/service/mod.rs
+++ b/helios-state/src/models/service/mod.rs
@@ -274,6 +274,7 @@ impl From<RemoteServiceTarget> for ServiceTarget {
                 cpu_shares: composition.cpu_shares.unwrap_or(0),
                 cap_add: composition.cap_add.unwrap_or_default(),
                 cap_drop: composition.cap_drop.unwrap_or_default(),
+                group_add: composition.group_add.unwrap_or_default(),
                 security_opt: composition.security_opt.unwrap_or_default(),
                 dns: composition.dns.unwrap_or_default(),
                 dns_opt: composition.dns_opt.unwrap_or_default(),

--- a/helios-state/src/models/service/mod.rs
+++ b/helios-state/src/models/service/mod.rs
@@ -282,6 +282,7 @@ impl From<RemoteServiceTarget> for ServiceTarget {
                 entrypoint,
                 environment,
                 extra_hosts: composition.extra_hosts.unwrap_or_default(),
+                sysctls: composition.sysctls.unwrap_or_default(),
                 hostname: composition.hostname,
                 init: composition.init,
                 labels,


### PR DESCRIPTION
Adds support for `cap_add`, `cap_drop`, `security_opt`, `sysctls` and `group_add`

- For `security_opt`, only `no-new-privileges`, `apparmor=unconfined` and `seccomp=unconfined` are allowed.
- For `sysctls`, only [valid kernel namespaces](https://docs.docker.com/reference/cli/docker/container/run/#sysctl) are accepted